### PR TITLE
ci: add automation for GitHub issues syncing

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,197 @@
+- name: 'kind: breaking-change'
+  description: ''
+  color: e11d21
+- name: 'kind: bug'
+  description: Categorizes issue or PR as related to a bug.
+  color: e11d21
+- name: 'kind: documentation'
+  description: Categorizes issue or PR as related to documentation.
+  color: d4c5f9
+- name: 'kind: enhancement'
+  description: Categorizes issue or PR as related to improving an existing feature.
+  color: d4c5f9
+- name: 'kind: failing-test'
+  description: |
+    Categorizes issue or PR as related to a consistently or frequently failing
+    test.
+  color: e11d21
+- name: 'kind: flakey'
+  description: Categorizes issue or PR as related to a flaky test.
+color: e11d21
+- name: 'kind: question'
+  description: Categorizes issue or PR as related to a question about the provider or
+  the use of the provider.
+  color: cc317c
+- name: 'kind: regression'
+  description: Categorizes issue or PR as related to a regression from a prior release.
+  color: e11d21
+- name: 'kind: support'
+  description: Categorizes issue or PR as related to user support.
+  color: e11d21
+- name: 'lifecycle: stale'
+  description: ''
+  color: e11d21
+- name: 'likelihood: all'
+  description: Categorizes issue or PR as impacting all users.
+  color: F7D2B6
+- name: 'likelihood: few'
+  description: Categorizes issue or PR as impacting a small portion of users.
+  color: F7D2B6
+- name: 'likelihood: low'
+  description: Categorizes issue or PR as impacting a low portion of users.
+  color: F7D2B6
+- name: 'likelihood: many'
+  description: Categorizes issue or PR as impacting many users.
+  color: F7D2B6
+- name: 'likelihood: most'
+  description: Categorizes issue or PR as impacting most users.
+  color: F7D2B6
+- name: needs-triage
+  description: Indicates an issue or PR lacks a `triage: foo` label and requires one.
+  color: ef9ed3
+- name: 'service: access'
+  description: Categorizes issue or PR as related to the Access service.
+  color: 98D063
+- name: 'service: addressing'
+  description: Categorizes issue or PR as related to the Addressing service.
+  color: 98D063
+- name: 'service: api-shield'
+  description: Categorizes issue or PR as related to the API shield service.
+  color: 98D063
+- name: 'service: argo'
+  description: Categorizes issue or PR as related to the Argo service.
+  color: 98D063
+- name: 'service: bot-management'
+  description: Categorizes issue or PR as related to the Bot Management service.
+  color: 98D063
+- name: 'service: byoip'
+  description: Categorizes issue or PR as related to the BYOIP service.
+  color: 98D063
+- name: 'service: cache'
+  description: Categorizes issue or PR as related to the Content Delivery service.
+  color: 98D063
+- name: 'service: custom-pages'
+  description: Categorizes issue or PR as related to the custom pages service.
+  color: 98D063
+- name: 'service: d1'
+  description: Categorizes issue or PR as related to the D1 service.
+  color: 98D063
+- name: 'service: dns'
+  description: Categorizes issue or PR as related to the DNS service.
+  color: 98D063
+- name: 'service: durable-objects'
+  description: Categorizes issue or PR as related to the Durable Objects service.
+  color: 98D063
+- name: 'service: firewall'
+  description: Categorizes issue or PR as related to the Firewall service.
+  color: 98D063
+- name: 'service: gateway'
+  description: Categorizes issue or PR as related to the Zero Trust Gateway service.
+  color: 98D063
+- name: 'service: iam'
+  description: Categorizes issue or PR as related to the IAM service.
+  color: 98D063
+- name: 'service: kv'
+  description: Categorizes issue or PR as related to the KV service.
+  color: 98D063
+- name: 'service: list'
+  description: Categorizes issue or PR as related to the List service.
+  color: 98D063
+- name: 'service: lists'
+  description: Categorizes issue or PR as related to the Lists service.
+  color: 98D063
+- name: 'service: load-balancing'
+  description: Categorizes issue or PR as related to the Load Balancing service.
+  color: 98D063
+- name: 'service: logs'
+  description: Categorizes issue or PR as related to the Logging services.
+  color: 98D063
+- name: 'service: magic-transit'
+  description: Categorizes issue or PR as related to Magic Transit services.
+  color: 98D063
+- name: 'service: magic-wan'
+  description: Categorizes issue or PR as related to the Magic WAN service.
+  color: 98D063
+- name: 'service: notifications'
+  description: Categorizes issue or PR as related to the notification service.
+  color: 98D063
+- name: 'service: page-rules'
+  description: Categorizes issue or PR as related to the Page Rules service.
+  color: 98D063
+- name: 'service: pages'
+  description: Categorizes issue or PR as related to the Pages service.
+  color: 98D063
+- name: 'service: r2'
+  description: Categorizes issue or PR as related to the R2 service.
+  color: 98D063
+- name: 'service: rulesets'
+  description: Categorizes issue or PR as related to the Rulesets service.
+  color: 98D063
+- name: 'service: spectrum'
+  description: Categorizes issue or PR as related to the Spectrum service.
+  color: 98D063
+- name: 'service: tls'
+  description: Categorizes issue or PR as related to the TLS services.
+  color: 98D063
+- name: 'service: tunnel'
+  description: Categorizes issue or PR as related to the Tunnel service.
+  color: 98D063
+- name: 'service: turnstile'
+  description: Categorizes issue or PR as related to Turnstile and the Challenge Platform
+  service.
+  color: 98D063
+- name: 'service: workers'
+  description: Categorizes issue or PR as related to the Workers service.
+  color: 98D063
+- name: 'service: zero-trust-devices'
+  description: Categorizes issue or PR as related to the Zero Trust Devices service.
+  color: 98D063
+- name: 'service: zones'
+  description: Categorizes issue or PR as related to the Zones service.
+  color: 98D063
+- name: spam
+  description: ''
+  color: e6f99f
+- name: 'triage: accepted'
+  description: Indicates an issue or PR is ready to be actively worked on.
+  color: fbca04
+- name: 'triage: duplicate'
+  description: Indicates an issue is a duplicate of other open issue.
+  color: fbca04
+- name: 'triage: needs-information'
+  description: Indicates an issue needs more information in order to work on it.
+  color: fbca04
+- name: 'triage: not-reproducible'
+  description: Indicates an issue can not be reproduced as described.
+  color: fbca04
+- name: 'triage: unresolved'
+  description: Indicates an issue that can not or will not be resolved.
+  color: fbca04
+- name: 'workflow: needs-review'
+  description: Indicates an issue or PR needs review or feedback.
+  color: 006b75
+- name: 'workflow: pending-cloudflare-response'
+  description: Indicates an issue or PR requires a response from the Cloudflare team.
+  color: 006b75
+- name: 'workflow: pending-contributor-response'
+  description: Indicates an issue or PR requires a response from a contributor.
+  color: 006b75
+- name: 'workflow: pending-maintainer-response'
+  description: Indicates an issue or PR requires a response from the maintainer team.
+  color: 006b75
+- name: 'workflow: pending-op-response'
+  description: Indicates an issue or PR requires a response from the original poster.
+  color: 006b75
+- name: 'workflow: pending-public-documentation'
+  description: Indicates an issue or PR requires changes to public documentation confirming
+  suitability for use.
+  color: 006b75
+- name: 'workflow: pending-upstream-library'
+  description: Indicates an issue or PR requires changes from an upstream library.
+  color: 006b75
+- name: 'workflow: pending-schemas'
+  description: Indicates an issue or PR requires changes from an upstream library.
+  color: 006b75
+- name: 'workflow: synced'
+  description: ''
+  color: 006b75

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,17 @@
+name: Sync labels
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/labels.yml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: micnncim/action-label-syncer@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manifest: .github/labels.yml


### PR DESCRIPTION
Updates the GitHub labels to be driven from a syncer instead of manually maintained.
