### PR TITLE
Update metadata property to support dynamic keys

### DIFF
--- a/src/resources/custom-hostnames/custom-hostnames.ts
+++ b/src/resources/custom-hostnames/custom-hostnames.ts
@@ -397,7 +397,7 @@ export namespace CustomHostname {
     /**
      * Unique metadata for this hostname.
      */
-    key?: string;
+    [key: string]: string;
   }
 
   /**


### PR DESCRIPTION
Previously, the `key` property was restricted to a static field. This change enables the use of dynamic keys for hostname metadata, allowing greater flexibility in defining custom parameters.

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

According to the documentation [here](https://developers.cloudflare.com/api-next/node/resources/custom_hostnames/methods/create/#(params)%20default) the custom_metadata property should be 

```ts
Record<string, string>
```
  instead of 

```ts
 export interface CustomMetadata {
    /**
     * Unique metadata for this hostname.
     */
    [key: string]: string;
  }

```
## Additional context & links
