### PR TITLE
chore: remove abort-controller

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "@types/node": "^18.11.18",
     "@types/node-fetch": "^2.6.4",
-    "abort-controller": "^3.0.0",
     "agentkeepalive": "^4.2.1",
     "form-data-encoder": "1.7.2",
     "formdata-node": "^4.3.2",

--- a/src/_shims/node-runtime.ts
+++ b/src/_shims/node-runtime.ts
@@ -5,7 +5,6 @@ import * as nf from 'node-fetch';
 import * as fd from 'formdata-node';
 import { type File, type FilePropertyBag } from 'formdata-node';
 import KeepAliveAgent from 'agentkeepalive';
-import { AbortController as AbortControllerPolyfill } from 'abort-controller';
 import { ReadStream as FsReadStream } from 'node:fs';
 import { type Agent } from 'node:http';
 import { FormDataEncoder } from 'form-data-encoder';
@@ -58,11 +57,6 @@ async function getMultipartRequestOptions<T = Record<string, unknown>>(
 }
 
 export function getRuntime(): Shims {
-  // Polyfill global object if needed.
-  if (typeof AbortController === 'undefined') {
-    // @ts-expect-error (the types are subtly different, but compatible in practice)
-    globalThis.AbortController = AbortControllerPolyfill;
-  }
   return {
     kind: 'node',
     fetch: nf.default,

--- a/yarn.lock
+++ b/yarn.lock
@@ -979,13 +979,6 @@
     "@typescript-eslint/types" "6.21.0"
     eslint-visitor-keys "^3.4.1"
 
-abort-controller@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
-  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
-  dependencies:
-    event-target-shim "^5.0.0"
-
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -1624,11 +1617,6 @@ esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
-
-event-target-shim@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
-  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 execa@^5.0.0:
   version "5.1.1"


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Remove abort-controller polyfill since it is no longer needed. This little change removes 2 dependencies.

All runtimes listed in the "Supported Runtimes" support it, incl. Cloudflare Workers and Vercel Edge Runtime.

See:

- https://developer.mozilla.org/en-US/docs/Web/API/AbortController#browser_compatibility
- https://vercel.com/docs/functions/runtimes/edge-runtime#other-web-standard-apis
- https://developers.cloudflare.com/workers/runtime-apis/web-standards/#abortcontroller-and-abortsignal

## Additional context & links
