### PR TITLE
change type from project.project_name to project.name

### DIFF
--- a/src/resources/pages/projects/projects.ts
+++ b/src/resources/pages/projects/projects.ts
@@ -187,7 +187,7 @@ export interface Deployment {
   /**
    * Name of the project.
    */
-  project_name?: string;
+  name?: string;
 
   /**
    * Short Id (8 character) of the deployment.


### PR DESCRIPTION
```md
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->
```

## Changes being requested

- [x] I understand that this repository is auto-generated and my pull request may not be merged

I tried to create an issue, but is disabled for normal users.

So requesting this as a PR instead.

Type `Deployment` has the wrong type, it should be `name` instead of `project_name`.

Since this code is autogenerated, just left this as reference for whoever can fix it.

## Additional context & links

If you want to run a test, this will do:

This doesn't work:

```ts
const apiToken = "ADD_YOUR_API_TOKEN";
const account_id = "ADD_YOUR_ACCOUNT_ID";

const client = new Cloudflare({ apiToken });

const projectList = (await client.pages.projects.list({account_id })).result;

const hasProjectName = projectList.every(p => p.project_name); // << wrong types!

if(!hasProjectName) throw new Error("expect hasProjectName to be defined");
```


But doing this instead does work:

```ts
const hasProjectName = projectList.every(p => p.name);
```