### PR TITLE
Update usage docs to show constructor with api tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,17 @@ The full API of this library can be found in [api.md](api.md).
 ```js
 import Cloudflare from 'cloudflare';
 
+// Using API Key and Email (default)
 const client = new Cloudflare({
   apiEmail: process.env['CLOUDFLARE_EMAIL'], // This is the default and can be omitted
   apiKey: process.env['CLOUDFLARE_API_KEY'], // This is the default and can be omitted
 });
+
+// Using API Tokens
+const client = new Cloudflare({
+  apiToken: process.env['CLOUDFLARE_API_TOKEN'] // Ensure CLOUDFLARE_EMAIL and CLOUDFLARE_API_KEY are not set in env
+});
+
 
 async function main() {
   const zone = await client.zones.create({


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Currently the cloudflare docs recommend api tokens as the preferred way to interact with the [eg](https://developers.cloudflare.com/api/resources/stream/subresources/live_inputs/methods/create/). However the default behavior of this library seems to be that if you have environment variables for CLOUDFLARE_EMAIL, CLOUDFLARE_API_KEY it will default to those creds. This change makes it a little more clear what the auth behavior is 

## Additional context & links
[Issue where I found the fix](https://github.com/cloudflare/cloudflare-typescript/issues/2454)