### PR TITLE
chore(client): don't throw a validation error for missing auth headers if using custom fetch

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -234,7 +234,7 @@ export abstract class APIClient {
   /**
    * Override this to add your own headers validation:
    */
-  protected validateHeaders(headers: Headers, customHeaders: Headers) {}
+  protected validateHeaders(headers: Headers, customHeaders: Headers, usingCustomFetch: boolean) {}
 
   protected defaultIdempotencyKey(): string {
     return `stainless-node-retry-${uuid4()}`;
@@ -397,7 +397,7 @@ export abstract class APIClient {
       reqHeaders['x-stainless-timeout'] = String(options.timeout);
     }
 
-    this.validateHeaders(reqHeaders, headers);
+    this.validateHeaders(reqHeaders, headers, this.fetch !== fetch);
 
     return reqHeaders;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -381,7 +381,11 @@ export class Cloudflare extends Core.APIClient {
     };
   }
 
-  protected override validateHeaders(headers: Core.Headers, customHeaders: Core.Headers) {
+  protected override validateHeaders(
+    headers: Core.Headers,
+    customHeaders: Core.Headers,
+    usingCustomFetch: boolean,
+  ) {
     if (this.apiEmail && headers['x-auth-email']) {
       return;
     }
@@ -407,6 +411,11 @@ export class Cloudflare extends Core.APIClient {
       return;
     }
     if (customHeaders['x-auth-user-service-key'] === null) {
+      return;
+    }
+
+    // we can't check for the presence of the headers with a custom fetch implementation, so we shouldn't throw an error
+    if (usingCustomFetch) {
       return;
     }
 


### PR DESCRIPTION


<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

This PR loosens the auth header validation when using a custom fetcher. Currently when using a custom fetcher that handles its own auth credentials, you have to instantiate the client with a dummy `apiToken` value in order to satisfy the validator. With this change, 

## Additional context & links
