### PR TITLE
fix: correctly handle sending multipart/form-data requests with JSON

### DIFF
--- a/src/resources/snippets/snippets.ts
+++ b/src/resources/snippets/snippets.ts
@@ -35,7 +35,7 @@ export class Snippets extends APIResource {
     return (
       this._client.put(
         `/zones/${zone_id}/snippets/${snippetName}`,
-        Core.multipartFormRequestOptions({ body, ...options }),
+        Core.multipartFormRequestOptions({ body, ...options, __multipartSyntax: 'json' }),
       ) as Core.APIPromise<{ result: SnippetUpdateResponse }>
     )._thenUnwrap((obj) => obj.result);
   }

--- a/src/resources/workers-for-platforms/dispatch/namespaces/scripts/content.ts
+++ b/src/resources/workers-for-platforms/dispatch/namespaces/scripts/content.ts
@@ -41,6 +41,7 @@ export class Content extends APIResource {
         Core.multipartFormRequestOptions({
           body,
           ...options,
+          __multipartSyntax: 'json',
           headers: {
             ...(cfWorkerBodyPart != null ? { 'CF-WORKER-BODY-PART': cfWorkerBodyPart } : undefined),
             ...(cfWorkerMainModulePart != null ?

--- a/src/resources/workers-for-platforms/dispatch/namespaces/scripts/settings.ts
+++ b/src/resources/workers-for-platforms/dispatch/namespaces/scripts/settings.ts
@@ -29,7 +29,7 @@ export class Settings extends APIResource {
     return (
       this._client.patch(
         `/accounts/${account_id}/workers/dispatch/namespaces/${dispatchNamespace}/scripts/${scriptName}/settings`,
-        Core.multipartFormRequestOptions({ body, ...options }),
+        Core.multipartFormRequestOptions({ body, ...options, __multipartSyntax: 'json' }),
       ) as Core.APIPromise<{ result: SettingEditResponse }>
     )._thenUnwrap((obj) => obj.result);
   }

--- a/src/resources/workers/scripts/content.ts
+++ b/src/resources/workers/scripts/content.ts
@@ -37,6 +37,7 @@ export class Content extends APIResource {
         Core.multipartFormRequestOptions({
           body,
           ...options,
+          __multipartSyntax: 'json',
           headers: {
             ...(cfWorkerBodyPart != null ? { 'CF-WORKER-BODY-PART': cfWorkerBodyPart } : undefined),
             ...(cfWorkerMainModulePart != null ?

--- a/src/resources/workers/scripts/script-and-version-settings.ts
+++ b/src/resources/workers/scripts/script-and-version-settings.ts
@@ -27,7 +27,7 @@ export class ScriptAndVersionSettings extends APIResource {
     return (
       this._client.patch(
         `/accounts/${account_id}/workers/scripts/${scriptName}/settings`,
-        Core.multipartFormRequestOptions({ body, ...options }),
+        Core.multipartFormRequestOptions({ body, ...options, __multipartSyntax: 'json' }),
       ) as Core.APIPromise<{ result: ScriptAndVersionSettingEditResponse }>
     )._thenUnwrap((obj) => obj.result);
   }


### PR DESCRIPTION
This PR includes a missing option to treat non-file parts of `multipart/form-data` requests as JSON as expected by several API endpoints.

Affected SDK methods:
- `client.snippets.update()`
- `client.workers.scripts.content.update()`
- `client.workers.scripts.scriptAndVersionSettings.edit()`
- `client.workersForPlatforms.dispatch.namespaces.scripts.content.update()`
- `client.workersForPlatforms.dispatch.namespaces.scripts.settings.edit()`

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
Fixes #2648 