### PR TITLE
fix: add missing 'active' status to DatabaseExportResponse type

### DIFF
--- a/src/resources/d1/database.ts
+++ b/src/resources/d1/database.ts
@@ -404,7 +404,7 @@ export interface DatabaseExportResponse {
    */
   result?: DatabaseExportResponse.Result;
 
-  status?: 'complete' | 'error';
+  status?: 'complete' | 'error' | 'active';
 
   success?: boolean;
 


### PR DESCRIPTION
## Description
Fixes #2669

The `DatabaseExportResponse` interface was missing the `'active'` status option, causing TypeScript errors when users tried to check `response.status == "active"` during D1 database export polling.

## Changes
- Added `'active'` to the status union type in `src/resources/d1/database.ts`
- Before: `status?: 'complete' | 'error';`
- After: `status?: 'complete' | 'error' | 'active';`

## Testing
- ✅ Created test case reproducing the original issue
- ✅ Verified TypeScript compilation passes with the fix
- ✅ No breaking changes to existing functionality

## Issue Reference
This resolves the TypeScript error reported in #2669:
