### PR TITLE
chore(ci): enable OIDC token generation in NPM workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -8,6 +8,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  id-token: write # required for OIDC
+
 jobs:
   publish:
     name: publish


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
This change allows GitHub Actions to generate OIDC tokens, which is a requirement of OIDC-based NPM publishing.

## Additional context & links
https://docs.npmjs.com/trusted-publishers