### PR TITLE
fix: add least-privilege permissions to all workflow jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
     name: lint
     runs-on: ${{ github.repository == 'stainless-sdks/cloudflare-node' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -77,6 +79,8 @@ jobs:
     name: test
     runs-on: ${{ github.repository == 'stainless-sdks/cloudflare-node' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -95,7 +99,8 @@ jobs:
     name: examples
     runs-on: ${{ github.repository == 'stainless-sdks/cloudflare-node' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.repository == 'cloudflare/cloudflare-typescript' && (github.event_name == 'push' || github.event.pull_request.head.repo.fork)
-
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/release-doctor.yml
+++ b/.github/workflows/release-doctor.yml
@@ -13,6 +13,8 @@ jobs:
   release_doctor:
     name: release doctor
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 2
     if: github.repository == 'cloudflare/cloudflare-typescript' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please') || github.head_ref == 'next')
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -7,6 +7,8 @@ jobs:
   semgrep:
     name: semgrep/ci
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
       SEMGREP_URL: https://cloudflare.semgrep.dev

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v2
       - uses: micnncim/action-label-syncer@v1


### PR DESCRIPTION
## Summary

Add explicit `permissions` blocks to all GitHub Actions workflow jobs that were missing them. Resolves 6 open code scanning alerts for `actions/missing-workflow-permissions`.

## Changes

| Workflow | Job | Permissions Added |
|----------|-----|-------------------|
| `ci.yml` | `lint` | `contents: read` |
| `ci.yml` | `test` | `contents: read` |
| `ci.yml` | `examples` | `contents: read` |
| `semgrep.yml` | `semgrep` | `contents: read` |
| `release-doctor.yml` | `release_doctor` | `contents: read` |
| `sync-labels.yml` | `build` | `contents: read`, `issues: write` |

The `build` job in `ci.yml` already had `permissions: { contents: read, id-token: write }` and is unchanged.

`sync-labels.yml` needs `issues: write` because the label syncer action creates/updates/deletes repo labels via the GitHub API.