### PR TITLE
fix: use post() for to-markdown endpoints to resolve async type error

### DIFF
--- a/src/resources/ai/ai.ts
+++ b/src/resources/ai/ai.ts
@@ -14,7 +14,6 @@ import {
   ToMarkdownSupportedResponsesSinglePage,
   ToMarkdownTransformParams,
   ToMarkdownTransformResponse,
-  ToMarkdownTransformResponsesSinglePage,
 } from './to-markdown';
 import * as FinetunesAPI from './finetunes/finetunes';
 import {
@@ -1114,7 +1113,6 @@ AI.Models = Models;
 AI.ModelListResponsesV4PagePaginationArray = ModelListResponsesV4PagePaginationArray;
 AI.ToMarkdown = ToMarkdown;
 AI.ToMarkdownSupportedResponsesSinglePage = ToMarkdownSupportedResponsesSinglePage;
-AI.ToMarkdownTransformResponsesSinglePage = ToMarkdownTransformResponsesSinglePage;
 
 export declare namespace AI {
   export { type AIRunResponse as AIRunResponse, type AIRunParams as AIRunParams };
@@ -1153,7 +1151,6 @@ export declare namespace AI {
     type ToMarkdownSupportedResponse as ToMarkdownSupportedResponse,
     type ToMarkdownTransformResponse as ToMarkdownTransformResponse,
     ToMarkdownSupportedResponsesSinglePage as ToMarkdownSupportedResponsesSinglePage,
-    ToMarkdownTransformResponsesSinglePage as ToMarkdownTransformResponsesSinglePage,
     type ToMarkdownSupportedParams as ToMarkdownSupportedParams,
     type ToMarkdownTransformParams as ToMarkdownTransformParams,
   };

--- a/src/resources/ai/index.ts
+++ b/src/resources/ai/index.ts
@@ -23,7 +23,6 @@ export {
 export { TaskListResponsesSinglePage, Tasks, type TaskListResponse, type TaskListParams } from './tasks';
 export {
   ToMarkdownSupportedResponsesSinglePage,
-  ToMarkdownTransformResponsesSinglePage,
   ToMarkdown,
   type ToMarkdownSupportedResponse,
   type ToMarkdownTransformResponse,

--- a/src/resources/ai/to-markdown.ts
+++ b/src/resources/ai/to-markdown.ts
@@ -26,19 +26,18 @@ export class ToMarkdown extends APIResource {
   transform(
     params: ToMarkdownTransformParams,
     options?: Core.RequestOptions,
-  ): Core.PagePromise<ToMarkdownTransformResponsesSinglePage, ToMarkdownTransformResponse> {
+  ): Core.APIPromise<ToMarkdownTransformResponse[]> {
     const { account_id, file } = params;
-    return this._client.getAPIList(
-      `/accounts/${account_id}/ai/tomarkdown`,
-      ToMarkdownTransformResponsesSinglePage,
-      Core.multipartFormRequestOptions({ body: file, method: 'post', ...options }),
-    );
+    return (
+      this._client.post(
+        `/accounts/${account_id}/ai/tomarkdown`,
+        Core.multipartFormRequestOptions({ body: file, ...options }),
+      ) as Core.APIPromise<{ result: ToMarkdownTransformResponse[] }>
+    )._thenUnwrap((obj) => obj.result);
   }
 }
 
 export class ToMarkdownSupportedResponsesSinglePage extends SinglePage<ToMarkdownSupportedResponse> {}
-
-export class ToMarkdownTransformResponsesSinglePage extends SinglePage<ToMarkdownTransformResponse> {}
 
 export interface ToMarkdownSupportedResponse {
   extension: string;
@@ -81,14 +80,12 @@ export namespace ToMarkdownTransformParams {
 }
 
 ToMarkdown.ToMarkdownSupportedResponsesSinglePage = ToMarkdownSupportedResponsesSinglePage;
-ToMarkdown.ToMarkdownTransformResponsesSinglePage = ToMarkdownTransformResponsesSinglePage;
 
 export declare namespace ToMarkdown {
   export {
     type ToMarkdownSupportedResponse as ToMarkdownSupportedResponse,
     type ToMarkdownTransformResponse as ToMarkdownTransformResponse,
     ToMarkdownSupportedResponsesSinglePage as ToMarkdownSupportedResponsesSinglePage,
-    ToMarkdownTransformResponsesSinglePage as ToMarkdownTransformResponsesSinglePage,
     type ToMarkdownSupportedParams as ToMarkdownSupportedParams,
     type ToMarkdownTransformParams as ToMarkdownTransformParams,
   };

--- a/src/resources/organizations/organization-profile.ts
+++ b/src/resources/organizations/organization-profile.ts
@@ -24,10 +24,7 @@ export class OrganizationProfileResource extends APIResource {
    * Get an organizations profile if it exists. (Currently in Closed Beta - see
    * https://developers.cloudflare.com/fundamentals/organizations/)
    */
-  get(
-    organizationId: string,
-    options?: Core.RequestOptions,
-  ): Core.APIPromise<OrganizationProfile> {
+  get(organizationId: string, options?: Core.RequestOptions): Core.APIPromise<OrganizationProfile> {
     return (
       this._client.get(`/organizations/${organizationId}/profile`, options) as Core.APIPromise<{
         result: OrganizationProfile;

--- a/src/resources/radar/ai/ai.ts
+++ b/src/resources/radar/ai/ai.ts
@@ -18,7 +18,6 @@ import {
   ToMarkdown,
   ToMarkdownCreateParams,
   ToMarkdownCreateResponse,
-  ToMarkdownCreateResponsesSinglePage,
 } from './to-markdown';
 import * as BotsAPI from './bots/bots';
 import {
@@ -49,7 +48,6 @@ export class AI extends APIResource {
 }
 
 AI.ToMarkdown = ToMarkdown;
-AI.ToMarkdownCreateResponsesSinglePage = ToMarkdownCreateResponsesSinglePage;
 AI.Inference = Inference;
 AI.Bots = Bots;
 AI.TimeseriesGroups = TimeseriesGroups;
@@ -58,7 +56,6 @@ export declare namespace AI {
   export {
     ToMarkdown as ToMarkdown,
     type ToMarkdownCreateResponse as ToMarkdownCreateResponse,
-    ToMarkdownCreateResponsesSinglePage as ToMarkdownCreateResponsesSinglePage,
     type ToMarkdownCreateParams as ToMarkdownCreateParams,
   };
 

--- a/src/resources/radar/ai/ai.ts
+++ b/src/resources/radar/ai/ai.ts
@@ -14,11 +14,7 @@ import {
   TimeseriesGroups,
 } from './timeseries-groups';
 import * as ToMarkdownAPI from './to-markdown';
-import {
-  ToMarkdown,
-  ToMarkdownCreateParams,
-  ToMarkdownCreateResponse,
-} from './to-markdown';
+import { ToMarkdown, ToMarkdownCreateParams, ToMarkdownCreateResponse } from './to-markdown';
 import * as BotsAPI from './bots/bots';
 import {
   BotSummaryV2Params,

--- a/src/resources/radar/ai/index.ts
+++ b/src/resources/radar/ai/index.ts
@@ -29,7 +29,6 @@ export {
   type TimeseriesGroupUserAgentParams,
 } from './timeseries-groups';
 export {
-  ToMarkdownCreateResponsesSinglePage,
   ToMarkdown,
   type ToMarkdownCreateResponse,
   type ToMarkdownCreateParams,

--- a/src/resources/radar/ai/index.ts
+++ b/src/resources/radar/ai/index.ts
@@ -28,8 +28,4 @@ export {
   type TimeseriesGroupTimeseriesGroupsParams,
   type TimeseriesGroupUserAgentParams,
 } from './timeseries-groups';
-export {
-  ToMarkdown,
-  type ToMarkdownCreateResponse,
-  type ToMarkdownCreateParams,
-} from './to-markdown';
+export { ToMarkdown, type ToMarkdownCreateResponse, type ToMarkdownCreateParams } from './to-markdown';

--- a/src/resources/radar/ai/to-markdown.ts
+++ b/src/resources/radar/ai/to-markdown.ts
@@ -2,7 +2,6 @@
 
 import { APIResource } from '../../../resource';
 import * as Core from '../../../core';
-import { SinglePage } from '../../../pagination';
 
 export class ToMarkdown extends APIResource {
   /**
@@ -13,17 +12,16 @@ export class ToMarkdown extends APIResource {
   create(
     params: ToMarkdownCreateParams,
     options?: Core.RequestOptions,
-  ): Core.PagePromise<ToMarkdownCreateResponsesSinglePage, ToMarkdownCreateResponse> {
+  ): Core.APIPromise<ToMarkdownCreateResponse[]> {
     const { account_id, ...body } = params;
-    return this._client.getAPIList(
-      `/accounts/${account_id}/ai/tomarkdown`,
-      ToMarkdownCreateResponsesSinglePage,
-      Core.multipartFormRequestOptions({ body, method: 'post', ...options }),
-    );
+    return (
+      this._client.post(
+        `/accounts/${account_id}/ai/tomarkdown`,
+        Core.multipartFormRequestOptions({ body, ...options }),
+      ) as Core.APIPromise<{ result: ToMarkdownCreateResponse[] }>
+    )._thenUnwrap((obj) => obj.result);
   }
 }
-
-export class ToMarkdownCreateResponsesSinglePage extends SinglePage<ToMarkdownCreateResponse> {}
 
 export interface ToMarkdownCreateResponse {
   data: string;
@@ -49,12 +47,9 @@ export interface ToMarkdownCreateParams {
   files: Array<Core.Uploadable>;
 }
 
-ToMarkdown.ToMarkdownCreateResponsesSinglePage = ToMarkdownCreateResponsesSinglePage;
-
 export declare namespace ToMarkdown {
   export {
     type ToMarkdownCreateResponse as ToMarkdownCreateResponse,
-    ToMarkdownCreateResponsesSinglePage as ToMarkdownCreateResponsesSinglePage,
     type ToMarkdownCreateParams as ToMarkdownCreateParams,
   };
 }

--- a/src/resources/workers/scripts/versions.ts
+++ b/src/resources/workers/scripts/versions.ts
@@ -31,7 +31,12 @@ export class Versions extends APIResource {
     return (
       this._client.post(
         `/accounts/${account_id}/workers/scripts/${scriptName}/versions`,
-        Core.multipartFormRequestOptions({ query: { bindings_inherit }, body, ...options, __multipartSyntax: 'json' }),
+        Core.multipartFormRequestOptions({
+          query: { bindings_inherit },
+          body,
+          ...options,
+          __multipartSyntax: 'json',
+        }),
       ) as Core.APIPromise<{ result: VersionCreateResponse }>
     )._thenUnwrap((obj) => obj.result);
   }


### PR DESCRIPTION
## Summary

Fix the TS2559 build errors in `ai/to-markdown.ts` and `radar/ai/to-markdown.ts` that cause CI build failures.

## Root Cause

`multipartFormRequestOptions()` is async (returns `Promise<RequestOptions>`) but `getAPIList()` only accepts sync `RequestOptions`. The codegen changed these endpoints from raw binary requests to multipart form requests, introducing the type mismatch.

## Fix

Switch from `getAPIList()` + `SinglePage` to `post()` + `_thenUnwrap()`. This works because:
- `post()` accepts `PromiseOrValue<RequestOptions>` (handles async options)
- These endpoints use `SinglePage` which is not actually paginated (`nextPageInfo()` always returns `null`)

## Files Changed

| File | Change |
|------|--------|
| `src/resources/ai/to-markdown.ts` | `transform`: use `post()` + unwrap, remove `SinglePage` class |
| `src/resources/radar/ai/to-markdown.ts` | `create`: use `post()` + unwrap, remove `SinglePage` class and import |
| `src/resources/ai/ai.ts` | Remove stale re-export |
| `src/resources/ai/index.ts` | Remove stale re-export |
| `src/resources/radar/ai/ai.ts` | Remove stale re-export |
| `src/resources/radar/ai/index.ts` | Remove stale re-export |

## Return Type Change

The return type changes from `PagePromise<SinglePage<T>, T>` to `APIPromise<T[]>`. `.asResponse()` and `.withResponse()` still work (they're on `APIPromise`). Async iteration is no longer available, but `SinglePage` never had a next page anyway.