### PR TITLE
chore(ci): disable breaking-change-detection for major version bump

### DIFF
--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -9,7 +9,9 @@ jobs:
   detect_breaking_changes:
     runs-on: 'ubuntu-latest'
     name: detect-breaking-changes
-    if: github.repository == 'cloudflare/cloudflare-typescript'
+    # Temporarily disabled: major version bump in progress — breaking changes are expected.
+    # Re-enable once the v<next> release is cut.
+    if: false
     steps:
       - name: Calculate fetch-depth
         run: |


### PR DESCRIPTION
## Summary

Temporarily disables the `detect_breaking_changes` CI job while a major version bump is in progress.

- Breaking changes are expected and intentional during a major release cycle.
- The job is disabled via `if: false` at the job level — all steps and the runner are skipped entirely.
- The workflow file is otherwise unchanged for easy restoration.

## Re-enabling

Once the major version is cut, restore the original condition:

\`\`\`yaml
if: github.repository == 'cloudflare/cloudflare-typescript'
\`\`\`