### PR TITLE
chore(ci): restore breaking-change-detection skip for major version bump

### DIFF
--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -9,7 +9,9 @@ jobs:
   detect_breaking_changes:
     runs-on: 'ubuntu-latest'
     name: detect-breaking-changes
-    if: github.repository == 'cloudflare/cloudflare-typescript'
+    # Temporarily disabled: major version bump in progress — breaking changes are expected.
+    # Re-enable once the v<next> release is cut.
+    if: false
     steps:
       - name: Calculate fetch-depth
         run: |


### PR DESCRIPTION
## Summary

The codegen sync PR (#2733) checked out `.github/workflows/detect-breaking-changes.yml` from `staging-next`, which overwrote the `if: false` skip added in #2732. This restores it.

The breaking-change-detection job should remain disabled until the next major version release is cut.