### PR TITLE
sync: integrate remaining staging-next codegen changes (2026-04-15)

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 2130
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/cloudflare%2Fcloudflare-ab609e3619850ae80630427118b42ff5b46f6ce33df8c5d921a06ee1fbc9ead4.yml
-openapi_spec_hash: 4bf317165b24e2deef370e50d511e5b0
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/cloudflare%2Fcloudflare-0e49d1dc0490c869be746d59e3e82fa07c02edae5f9b421033c9b94807974de6.yml
+openapi_spec_hash: 6858d3cd0d37b23dac9544a532a19d82
 config_hash: 591b4fc9102b68593471cf59ef305cb8

--- a/src/resources/ai/ai.ts
+++ b/src/resources/ai/ai.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';
+import { isRequestOptions } from '../../core';
 import * as Core from '../../core';
 import * as AuthorsAPI from './authors';
 import { AuthorListParams, AuthorListResponse, AuthorListResponsesSinglePage, Authors } from './authors';
@@ -49,8 +50,17 @@ export class AI extends APIResource {
    * Model specific inputs available in
    * [Cloudflare Docs](https://developers.cloudflare.com/workers-ai/models/).
    */
-  run(modelName: string, params: AIRunParams, options?: Core.RequestOptions): Core.APIPromise<AIRunResponse> {
-    const { account_id, ...body } = params;
+  run(modelName: string, params?: AIRunParams, options?: Core.RequestOptions): Core.APIPromise<AIRunResponse>;
+  run(modelName: string, options?: Core.RequestOptions): Core.APIPromise<AIRunResponse>;
+  run(
+    modelName: string,
+    params: AIRunParams | Core.RequestOptions = {},
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<AIRunResponse> {
+    if (isRequestOptions(params)) {
+      return this.run(modelName, {}, params);
+    }
+    const { account_id = this._client.accountId, ...body } = params;
     return (
       this._client.post(`/accounts/${account_id}/ai/run/${modelName}`, {
         body,
@@ -298,7 +308,7 @@ export declare namespace AIRunParams {
     /**
      * Path param
      */
-    account_id: string;
+    account_id?: string;
 
     /**
      * Body param: The text that you want to classify
@@ -310,7 +320,7 @@ export declare namespace AIRunParams {
     /**
      * Path param
      */
-    account_id: string;
+    account_id?: string;
 
     /**
      * Body param: A text description of the image you want to generate
@@ -379,7 +389,7 @@ export declare namespace AIRunParams {
     /**
      * Path param
      */
-    account_id: string;
+    account_id?: string;
 
     /**
      * Body param: A text description of the audio you want to generate
@@ -397,7 +407,7 @@ export declare namespace AIRunParams {
     /**
      * Path param
      */
-    account_id: string;
+    account_id?: string;
 
     /**
      * Body param: The text to embed
@@ -409,7 +419,7 @@ export declare namespace AIRunParams {
     /**
      * Path param
      */
-    account_id: string;
+    account_id?: string;
 
     /**
      * Body param: An array of integers that represent the audio data constrained to
@@ -433,7 +443,7 @@ export declare namespace AIRunParams {
     /**
      * Path param
      */
-    account_id: string;
+    account_id?: string;
 
     /**
      * Body param: An array of integers that represent the image data constrained to
@@ -446,7 +456,7 @@ export declare namespace AIRunParams {
     /**
      * Path param
      */
-    account_id: string;
+    account_id?: string;
 
     /**
      * Body param: An array of integers that represent the image data constrained to
@@ -459,7 +469,7 @@ export declare namespace AIRunParams {
     /**
      * Path param
      */
-    account_id: string;
+    account_id?: string;
 
     /**
      * Body param: The input text prompt for the model to generate a response.
@@ -548,7 +558,7 @@ export declare namespace AIRunParams {
     /**
      * Path param
      */
-    account_id: string;
+    account_id?: string;
 
     /**
      * Body param: An array of message objects representing the conversation history.
@@ -796,7 +806,7 @@ export declare namespace AIRunParams {
     /**
      * Path param
      */
-    account_id: string;
+    account_id?: string;
 
     /**
      * Body param: The language code to translate the text into (e.g., 'es' for
@@ -820,7 +830,7 @@ export declare namespace AIRunParams {
     /**
      * Path param
      */
-    account_id: string;
+    account_id?: string;
 
     /**
      * Body param: The text that you want the model to summarize
@@ -837,7 +847,7 @@ export declare namespace AIRunParams {
     /**
      * Path param
      */
-    account_id: string;
+    account_id?: string;
 
     /**
      * Body param: An array of integers that represent the image data constrained to
@@ -907,7 +917,7 @@ export declare namespace AIRunParams {
     /**
      * Path param
      */
-    account_id: string;
+    account_id?: string;
 
     /**
      * Body param: Image in base64 encoded format.
@@ -976,7 +986,7 @@ export declare namespace AIRunParams {
     /**
      * Path param
      */
-    account_id: string;
+    account_id?: string;
 
     /**
      * Body param: Image in base64 encoded format.
@@ -1090,7 +1100,7 @@ export declare namespace AIRunParams {
     /**
      * Path param
      */
-    account_id: string;
+    account_id?: string;
 
     /**
      * Body param: Image in base64 encoded format.

--- a/src/resources/ai/authors.ts
+++ b/src/resources/ai/authors.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';
+import { isRequestOptions } from '../../core';
 import * as Core from '../../core';
 import { SinglePage } from '../../pagination';
 
@@ -9,10 +10,18 @@ export class Authors extends APIResource {
    * Searches Workers AI models by author or organization name.
    */
   list(
-    params: AuthorListParams,
+    params?: AuthorListParams,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<AuthorListResponsesSinglePage, AuthorListResponse>;
+  list(options?: Core.RequestOptions): Core.PagePromise<AuthorListResponsesSinglePage, AuthorListResponse>;
+  list(
+    params: AuthorListParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.PagePromise<AuthorListResponsesSinglePage, AuthorListResponse> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.list({}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return this._client.getAPIList(
       `/accounts/${account_id}/ai/authors/search`,
       AuthorListResponsesSinglePage,
@@ -26,7 +35,7 @@ export class AuthorListResponsesSinglePage extends SinglePage<AuthorListResponse
 export type AuthorListResponse = unknown;
 
 export interface AuthorListParams {
-  account_id: string;
+  account_id?: string;
 }
 
 Authors.AuthorListResponsesSinglePage = AuthorListResponsesSinglePage;

--- a/src/resources/ai/finetunes/assets.ts
+++ b/src/resources/ai/finetunes/assets.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../../resource';
+import { isRequestOptions } from '../../../core';
 import * as Core from '../../../core';
 
 export class Assets extends APIResource {
@@ -9,10 +10,19 @@ export class Assets extends APIResource {
    */
   create(
     finetuneId: string,
-    params: AssetCreateParams,
+    params?: AssetCreateParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<AssetCreateResponse>;
+  create(finetuneId: string, options?: Core.RequestOptions): Core.APIPromise<AssetCreateResponse>;
+  create(
+    finetuneId: string,
+    params: AssetCreateParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<AssetCreateResponse> {
-    const { account_id, ...body } = params;
+    if (isRequestOptions(params)) {
+      return this.create(finetuneId, {}, params);
+    }
+    const { account_id = this._client.accountId, ...body } = params;
     return this._client.post(
       `/accounts/${account_id}/ai/finetunes/${finetuneId}/finetune-assets`,
       Core.multipartFormRequestOptions({ body, ...options }),
@@ -28,7 +38,7 @@ export interface AssetCreateParams {
   /**
    * Path param
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param

--- a/src/resources/ai/finetunes/finetunes.ts
+++ b/src/resources/ai/finetunes/finetunes.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../../resource';
+import { isRequestOptions } from '../../../core';
 import * as Core from '../../../core';
 import * as AssetsAPI from './assets';
 import { AssetCreateParams, AssetCreateResponse, Assets } from './assets';
@@ -18,7 +19,7 @@ export class Finetunes extends APIResource {
     params: FinetuneCreateParams,
     options?: Core.RequestOptions,
   ): Core.APIPromise<FinetuneCreateResponse> {
-    const { account_id, ...body } = params;
+    const { account_id = this._client.accountId, ...body } = params;
     return (
       this._client.post(`/accounts/${account_id}/ai/finetunes`, { body, ...options }) as Core.APIPromise<{
         result: FinetuneCreateResponse;
@@ -29,8 +30,16 @@ export class Finetunes extends APIResource {
   /**
    * Lists all fine-tuning jobs created by the account, including status and metrics.
    */
-  list(params: FinetuneListParams, options?: Core.RequestOptions): Core.APIPromise<FinetuneListResponse> {
-    const { account_id } = params;
+  list(params?: FinetuneListParams, options?: Core.RequestOptions): Core.APIPromise<FinetuneListResponse>;
+  list(options?: Core.RequestOptions): Core.APIPromise<FinetuneListResponse>;
+  list(
+    params: FinetuneListParams | Core.RequestOptions = {},
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<FinetuneListResponse> {
+    if (isRequestOptions(params)) {
+      return this.list({}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return (
       this._client.get(`/accounts/${account_id}/ai/finetunes`, options) as Core.APIPromise<{
         result: FinetuneListResponse;
@@ -73,7 +82,7 @@ export interface FinetuneCreateParams {
   /**
    * Path param
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param
@@ -97,7 +106,7 @@ export interface FinetuneCreateParams {
 }
 
 export interface FinetuneListParams {
-  account_id: string;
+  account_id?: string;
 }
 
 Finetunes.Assets = Assets;

--- a/src/resources/ai/finetunes/public.ts
+++ b/src/resources/ai/finetunes/public.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../../resource';
+import { isRequestOptions } from '../../../core';
 import * as Core from '../../../core';
 import { SinglePage } from '../../../pagination';
 
@@ -9,10 +10,18 @@ export class Public extends APIResource {
    * Lists publicly available fine-tuned models that can be used with Workers AI.
    */
   list(
-    params: PublicListParams,
+    params?: PublicListParams,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<PublicListResponsesSinglePage, PublicListResponse>;
+  list(options?: Core.RequestOptions): Core.PagePromise<PublicListResponsesSinglePage, PublicListResponse>;
+  list(
+    params: PublicListParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.PagePromise<PublicListResponsesSinglePage, PublicListResponse> {
-    const { account_id, ...query } = params;
+    if (isRequestOptions(params)) {
+      return this.list({}, params);
+    }
+    const { account_id = this._client.accountId, ...query } = params;
     return this._client.getAPIList(
       `/accounts/${account_id}/ai/finetunes/public`,
       PublicListResponsesSinglePage,
@@ -43,7 +52,7 @@ export interface PublicListParams {
   /**
    * Path param
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Query param: Pagination Limit

--- a/src/resources/ai/models/models.ts
+++ b/src/resources/ai/models/models.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../../resource';
+import { isRequestOptions } from '../../../core';
 import * as Core from '../../../core';
 import * as SchemaAPI from './schema';
 import { Schema, SchemaGetParams, SchemaGetResponse } from './schema';
@@ -13,10 +14,20 @@ export class Models extends APIResource {
    * Searches Workers AI models by name or description.
    */
   list(
-    params: ModelListParams,
+    params?: ModelListParams,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<ModelListResponsesV4PagePaginationArray, ModelListResponse>;
+  list(
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<ModelListResponsesV4PagePaginationArray, ModelListResponse>;
+  list(
+    params: ModelListParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.PagePromise<ModelListResponsesV4PagePaginationArray, ModelListResponse> {
-    const { account_id, ...query } = params;
+    if (isRequestOptions(params)) {
+      return this.list({}, params);
+    }
+    const { account_id = this._client.accountId, ...query } = params;
     return this._client.getAPIList(
       `/accounts/${account_id}/ai/models/search`,
       ModelListResponsesV4PagePaginationArray,
@@ -33,7 +44,7 @@ export interface ModelListParams extends V4PagePaginationArrayParams {
   /**
    * Path param
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Query param: Filter by Author

--- a/src/resources/ai/models/schema.ts
+++ b/src/resources/ai/models/schema.ts
@@ -8,7 +8,7 @@ export class Schema extends APIResource {
    * Retrieves the input and output JSON schema definition for a Workers AI model.
    */
   get(params: SchemaGetParams, options?: Core.RequestOptions): Core.APIPromise<SchemaGetResponse> {
-    const { account_id, ...query } = params;
+    const { account_id = this._client.accountId, ...query } = params;
     return (
       this._client.get(`/accounts/${account_id}/ai/models/schema`, { query, ...options }) as Core.APIPromise<{
         result: SchemaGetResponse;
@@ -45,7 +45,7 @@ export interface SchemaGetParams {
   /**
    * Path param
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Query param: Model Name

--- a/src/resources/ai/tasks.ts
+++ b/src/resources/ai/tasks.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';
+import { isRequestOptions } from '../../core';
 import * as Core from '../../core';
 import { SinglePage } from '../../pagination';
 
@@ -9,10 +10,18 @@ export class Tasks extends APIResource {
    * Searches Workers AI models by task type (e.g., text-generation, embeddings).
    */
   list(
-    params: TaskListParams,
+    params?: TaskListParams,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<TaskListResponsesSinglePage, TaskListResponse>;
+  list(options?: Core.RequestOptions): Core.PagePromise<TaskListResponsesSinglePage, TaskListResponse>;
+  list(
+    params: TaskListParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.PagePromise<TaskListResponsesSinglePage, TaskListResponse> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.list({}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return this._client.getAPIList(
       `/accounts/${account_id}/ai/tasks/search`,
       TaskListResponsesSinglePage,
@@ -26,7 +35,7 @@ export class TaskListResponsesSinglePage extends SinglePage<TaskListResponse> {}
 export type TaskListResponse = unknown;
 
 export interface TaskListParams {
-  account_id: string;
+  account_id?: string;
 }
 
 Tasks.TaskListResponsesSinglePage = TaskListResponsesSinglePage;

--- a/src/resources/ai/to-markdown.ts
+++ b/src/resources/ai/to-markdown.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';
+import { isRequestOptions } from '../../core';
 import * as Core from '../../core';
 import { SinglePage } from '../../pagination';
 
@@ -9,10 +10,20 @@ export class ToMarkdown extends APIResource {
    * Lists all file formats supported for conversion to Markdown.
    */
   supported(
-    params: ToMarkdownSupportedParams,
+    params?: ToMarkdownSupportedParams,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<ToMarkdownSupportedResponsesSinglePage, ToMarkdownSupportedResponse>;
+  supported(
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<ToMarkdownSupportedResponsesSinglePage, ToMarkdownSupportedResponse>;
+  supported(
+    params: ToMarkdownSupportedParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.PagePromise<ToMarkdownSupportedResponsesSinglePage, ToMarkdownSupportedResponse> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.supported({}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return this._client.getAPIList(
       `/accounts/${account_id}/ai/tomarkdown/supported`,
       ToMarkdownSupportedResponsesSinglePage,
@@ -27,7 +38,7 @@ export class ToMarkdown extends APIResource {
     params: ToMarkdownTransformParams,
     options?: Core.RequestOptions,
   ): Core.APIPromise<ToMarkdownTransformResponse[]> {
-    const { account_id, file } = params;
+    const { account_id = this._client.accountId, file } = params;
     return (
       this._client.post(
         `/accounts/${account_id}/ai/tomarkdown`,
@@ -58,14 +69,14 @@ export interface ToMarkdownTransformResponse {
 }
 
 export interface ToMarkdownSupportedParams {
-  account_id: string;
+  account_id?: string;
 }
 
 export interface ToMarkdownTransformParams {
   /**
    * Path param
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param

--- a/src/resources/radar/agent-readiness.ts
+++ b/src/resources/radar/agent-readiness.ts
@@ -1,0 +1,146 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+import { APIResource } from '../../resource';
+import { isRequestOptions } from '../../core';
+import * as Core from '../../core';
+
+export class AgentReadiness extends APIResource {
+  /**
+   * Returns a summary of AI agent readiness scores across scanned domains, grouped
+   * by the specified dimension. Data is sourced from weekly bulk scans. All values
+   * are raw domain counts.
+   *
+   * @example
+   * ```ts
+   * const response = await client.radar.agentReadiness.summary(
+   *   'CHECK',
+   * );
+   * ```
+   */
+  summary(
+    dimension: 'CHECK',
+    query?: AgentReadinessSummaryParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<AgentReadinessSummaryResponse>;
+  summary(dimension: 'CHECK', options?: Core.RequestOptions): Core.APIPromise<AgentReadinessSummaryResponse>;
+  summary(
+    dimension: 'CHECK',
+    query: AgentReadinessSummaryParams | Core.RequestOptions = {},
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<AgentReadinessSummaryResponse> {
+    if (isRequestOptions(query)) {
+      return this.summary(dimension, {}, query);
+    }
+    return (
+      this._client.get(`/radar/agent_readiness/summary/${dimension}`, {
+        query,
+        ...options,
+      }) as Core.APIPromise<{ result: AgentReadinessSummaryResponse }>
+    )._thenUnwrap((obj) => obj.result);
+  }
+}
+
+export interface AgentReadinessSummaryResponse {
+  meta: AgentReadinessSummaryResponse.Meta;
+
+  summary_0: { [key: string]: string };
+}
+
+export namespace AgentReadinessSummaryResponse {
+  export interface Meta {
+    /**
+     * Date of the returned scan (YYYY-MM-DD). May differ from the requested date if no
+     * scan exists for that exact date.
+     */
+    date: string;
+
+    /**
+     * Available domain sub-categories with their scan counts. Use as filter options
+     * for the domainCategory parameter.
+     */
+    domainCategories: Array<Meta.DomainCategory>;
+
+    /**
+     * Timestamp of the last dataset update.
+     */
+    lastUpdated: string;
+
+    /**
+     * Normalization method applied to the results. Refer to
+     * [Normalization methods](https://developers.cloudflare.com/radar/concepts/normalization/).
+     */
+    normalization:
+      | 'PERCENTAGE'
+      | 'MIN0_MAX'
+      | 'MIN_MAX'
+      | 'RAW_VALUES'
+      | 'PERCENTAGE_CHANGE'
+      | 'ROLLING_AVERAGE'
+      | 'OVERLAPPED_PERCENTAGE'
+      | 'RATIO';
+
+    /**
+     * Domains successfully scanned (excludes errors).
+     */
+    successfulDomains: number;
+
+    /**
+     * Total domains attempted in the scan.
+     */
+    totalDomains: number;
+
+    /**
+     * Measurement units for the results.
+     */
+    units: Array<Meta.Unit>;
+  }
+
+  export namespace Meta {
+    export interface DomainCategory {
+      /**
+       * Sub-category name.
+       */
+      name: string;
+
+      /**
+       * Number of successfully scanned domains in this sub-category.
+       */
+      value: number;
+    }
+
+    export interface Unit {
+      name: string;
+
+      value: string;
+    }
+  }
+}
+
+export interface AgentReadinessSummaryParams {
+  /**
+   * Filters results by the specified date.
+   */
+  date?: string;
+
+  /**
+   * Filters results by domain category.
+   */
+  domainCategory?: Array<string>;
+
+  /**
+   * Format in which results will be returned.
+   */
+  format?: 'JSON' | 'CSV';
+
+  /**
+   * Array of names used to label the series in the response.
+   */
+  name?: Array<string>;
+}
+
+export declare namespace AgentReadiness {
+  export {
+    type AgentReadinessSummaryResponse as AgentReadinessSummaryResponse,
+    type AgentReadinessSummaryParams as AgentReadinessSummaryParams,
+  };
+}

--- a/src/resources/radar/ai/ai.ts
+++ b/src/resources/radar/ai/ai.ts
@@ -1,6 +1,14 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../../resource';
+import * as MarkdownForAgentsAPI from './markdown-for-agents';
+import {
+  MarkdownForAgentSummaryParams,
+  MarkdownForAgentSummaryResponse,
+  MarkdownForAgentTimeseriesParams,
+  MarkdownForAgentTimeseriesResponse,
+  MarkdownForAgents,
+} from './markdown-for-agents';
 import * as TimeseriesGroupsAPI from './timeseries-groups';
 import {
   TimeseriesGroupSummaryParams,
@@ -41,12 +49,16 @@ export class AI extends APIResource {
   timeseriesGroups: TimeseriesGroupsAPI.TimeseriesGroups = new TimeseriesGroupsAPI.TimeseriesGroups(
     this._client,
   );
+  markdownForAgents: MarkdownForAgentsAPI.MarkdownForAgents = new MarkdownForAgentsAPI.MarkdownForAgents(
+    this._client,
+  );
 }
 
 AI.ToMarkdown = ToMarkdown;
 AI.Inference = Inference;
 AI.Bots = Bots;
 AI.TimeseriesGroups = TimeseriesGroups;
+AI.MarkdownForAgents = MarkdownForAgents;
 
 export declare namespace AI {
   export {
@@ -83,5 +95,13 @@ export declare namespace AI {
     type TimeseriesGroupTimeseriesParams as TimeseriesGroupTimeseriesParams,
     type TimeseriesGroupTimeseriesGroupsParams as TimeseriesGroupTimeseriesGroupsParams,
     type TimeseriesGroupUserAgentParams as TimeseriesGroupUserAgentParams,
+  };
+
+  export {
+    MarkdownForAgents as MarkdownForAgents,
+    type MarkdownForAgentSummaryResponse as MarkdownForAgentSummaryResponse,
+    type MarkdownForAgentTimeseriesResponse as MarkdownForAgentTimeseriesResponse,
+    type MarkdownForAgentSummaryParams as MarkdownForAgentSummaryParams,
+    type MarkdownForAgentTimeseriesParams as MarkdownForAgentTimeseriesParams,
   };
 }

--- a/src/resources/radar/ai/index.ts
+++ b/src/resources/radar/ai/index.ts
@@ -18,6 +18,13 @@ export {
   type InferenceTimeseriesGroupsV2Params,
 } from './inference/index';
 export {
+  MarkdownForAgents,
+  type MarkdownForAgentSummaryResponse,
+  type MarkdownForAgentTimeseriesResponse,
+  type MarkdownForAgentSummaryParams,
+  type MarkdownForAgentTimeseriesParams,
+} from './markdown-for-agents';
+export {
   TimeseriesGroups,
   type TimeseriesGroupSummaryResponse,
   type TimeseriesGroupTimeseriesResponse,

--- a/src/resources/radar/ai/markdown-for-agents.ts
+++ b/src/resources/radar/ai/markdown-for-agents.ts
@@ -1,0 +1,418 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+import { APIResource } from '../../../resource';
+import { isRequestOptions } from '../../../core';
+import * as Core from '../../../core';
+
+export class MarkdownForAgents extends APIResource {
+  /**
+   * Retrieves the overall median HTML-to-markdown reduction ratio for AI agent
+   * requests over the given date range.
+   *
+   * @example
+   * ```ts
+   * const response =
+   *   await client.radar.ai.markdownForAgents.summary();
+   * ```
+   */
+  summary(
+    query?: MarkdownForAgentSummaryParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<MarkdownForAgentSummaryResponse>;
+  summary(options?: Core.RequestOptions): Core.APIPromise<MarkdownForAgentSummaryResponse>;
+  summary(
+    query: MarkdownForAgentSummaryParams | Core.RequestOptions = {},
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<MarkdownForAgentSummaryResponse> {
+    if (isRequestOptions(query)) {
+      return this.summary({}, query);
+    }
+    return (
+      this._client.get('/radar/ai/markdown_for_agents/summary', { query, ...options }) as Core.APIPromise<{
+        result: MarkdownForAgentSummaryResponse;
+      }>
+    )._thenUnwrap((obj) => obj.result);
+  }
+
+  /**
+   * Retrieves the median HTML-to-markdown reduction ratio over time for AI agent
+   * requests.
+   *
+   * @example
+   * ```ts
+   * const response =
+   *   await client.radar.ai.markdownForAgents.timeseries();
+   * ```
+   */
+  timeseries(
+    query?: MarkdownForAgentTimeseriesParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<MarkdownForAgentTimeseriesResponse>;
+  timeseries(options?: Core.RequestOptions): Core.APIPromise<MarkdownForAgentTimeseriesResponse>;
+  timeseries(
+    query: MarkdownForAgentTimeseriesParams | Core.RequestOptions = {},
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<MarkdownForAgentTimeseriesResponse> {
+    if (isRequestOptions(query)) {
+      return this.timeseries({}, query);
+    }
+    return (
+      this._client.get('/radar/ai/markdown_for_agents/timeseries', { query, ...options }) as Core.APIPromise<{
+        result: MarkdownForAgentTimeseriesResponse;
+      }>
+    )._thenUnwrap((obj) => obj.result);
+  }
+}
+
+export interface MarkdownForAgentSummaryResponse {
+  /**
+   * Metadata for the results.
+   */
+  meta: MarkdownForAgentSummaryResponse.Meta;
+
+  summary_0: MarkdownForAgentSummaryResponse.Summary0;
+}
+
+export namespace MarkdownForAgentSummaryResponse {
+  /**
+   * Metadata for the results.
+   */
+  export interface Meta {
+    confidenceInfo: Meta.ConfidenceInfo;
+
+    dateRange: Array<Meta.DateRange>;
+
+    /**
+     * Timestamp of the last dataset update.
+     */
+    lastUpdated: string;
+
+    /**
+     * Normalization method applied to the results. Refer to
+     * [Normalization methods](https://developers.cloudflare.com/radar/concepts/normalization/).
+     */
+    normalization:
+      | 'PERCENTAGE'
+      | 'MIN0_MAX'
+      | 'MIN_MAX'
+      | 'RAW_VALUES'
+      | 'PERCENTAGE_CHANGE'
+      | 'ROLLING_AVERAGE'
+      | 'OVERLAPPED_PERCENTAGE'
+      | 'RATIO';
+
+    /**
+     * Measurement units for the results.
+     */
+    units: Array<Meta.Unit>;
+  }
+
+  export namespace Meta {
+    export interface ConfidenceInfo {
+      annotations: Array<ConfidenceInfo.Annotation>;
+
+      /**
+       * Provides an indication of how much confidence Cloudflare has in the data.
+       */
+      level: number;
+    }
+
+    export namespace ConfidenceInfo {
+      /**
+       * Annotation associated with the result (e.g. outage or other type of event).
+       */
+      export interface Annotation {
+        /**
+         * Data source for annotations.
+         */
+        dataSource:
+          | 'ALL'
+          | 'AI_BOTS'
+          | 'AI_GATEWAY'
+          | 'BGP'
+          | 'BOTS'
+          | 'CONNECTION_ANOMALY'
+          | 'CT'
+          | 'DNS'
+          | 'DNS_MAGNITUDE'
+          | 'DNS_AS112'
+          | 'DOS'
+          | 'EMAIL_ROUTING'
+          | 'EMAIL_SECURITY'
+          | 'FW'
+          | 'FW_PG'
+          | 'HTTP'
+          | 'HTTP_CONTROL'
+          | 'HTTP_CRAWLER_REFERER'
+          | 'HTTP_ORIGINS'
+          | 'IQI'
+          | 'LEAKED_CREDENTIALS'
+          | 'NET'
+          | 'ROBOTS_TXT'
+          | 'SPEED'
+          | 'WORKERS_AI';
+
+        description: string;
+
+        endDate: string;
+
+        /**
+         * Event type for annotations.
+         */
+        eventType: 'EVENT' | 'GENERAL' | 'OUTAGE' | 'PARTIAL_PROJECTION' | 'PIPELINE' | 'TRAFFIC_ANOMALY';
+
+        /**
+         * Whether event is a single point in time or a time range.
+         */
+        isInstantaneous: boolean;
+
+        linkedUrl: string;
+
+        startDate: string;
+      }
+    }
+
+    export interface DateRange {
+      /**
+       * Adjusted end of date range.
+       */
+      endTime: string;
+
+      /**
+       * Adjusted start of date range.
+       */
+      startTime: string;
+    }
+
+    export interface Unit {
+      name: string;
+
+      value: string;
+    }
+  }
+
+  export interface Summary0 {
+    /**
+     * A numeric string that can include decimals and infinity values.
+     */
+    value: string;
+  }
+}
+
+export interface MarkdownForAgentTimeseriesResponse {
+  /**
+   * Metadata for the results.
+   */
+  meta: MarkdownForAgentTimeseriesResponse.Meta;
+
+  [k: string]:
+    | MarkdownForAgentTimeseriesResponse.unnamed_schema_ref_75bae70cf28e6bcef364b9840db3bdeb
+    | MarkdownForAgentTimeseriesResponse.Meta
+    | undefined;
+}
+
+export namespace MarkdownForAgentTimeseriesResponse {
+  /**
+   * Metadata for the results.
+   */
+  export interface Meta {
+    /**
+     * Aggregation interval of the results (e.g., in 15 minutes or 1 hour intervals).
+     * Refer to
+     * [Aggregation intervals](https://developers.cloudflare.com/radar/concepts/aggregation-intervals/).
+     */
+    aggInterval: 'FIFTEEN_MINUTES' | 'ONE_HOUR' | 'ONE_DAY' | 'ONE_WEEK' | 'ONE_MONTH';
+
+    confidenceInfo: Meta.ConfidenceInfo;
+
+    dateRange: Array<Meta.DateRange>;
+
+    /**
+     * Timestamp of the last dataset update.
+     */
+    lastUpdated: string;
+
+    /**
+     * Normalization method applied to the results. Refer to
+     * [Normalization methods](https://developers.cloudflare.com/radar/concepts/normalization/).
+     */
+    normalization:
+      | 'PERCENTAGE'
+      | 'MIN0_MAX'
+      | 'MIN_MAX'
+      | 'RAW_VALUES'
+      | 'PERCENTAGE_CHANGE'
+      | 'ROLLING_AVERAGE'
+      | 'OVERLAPPED_PERCENTAGE'
+      | 'RATIO';
+
+    /**
+     * Measurement units for the results.
+     */
+    units: Array<Meta.Unit>;
+  }
+
+  export namespace Meta {
+    export interface ConfidenceInfo {
+      annotations: Array<ConfidenceInfo.Annotation>;
+
+      /**
+       * Provides an indication of how much confidence Cloudflare has in the data.
+       */
+      level: number;
+    }
+
+    export namespace ConfidenceInfo {
+      /**
+       * Annotation associated with the result (e.g. outage or other type of event).
+       */
+      export interface Annotation {
+        /**
+         * Data source for annotations.
+         */
+        dataSource:
+          | 'ALL'
+          | 'AI_BOTS'
+          | 'AI_GATEWAY'
+          | 'BGP'
+          | 'BOTS'
+          | 'CONNECTION_ANOMALY'
+          | 'CT'
+          | 'DNS'
+          | 'DNS_MAGNITUDE'
+          | 'DNS_AS112'
+          | 'DOS'
+          | 'EMAIL_ROUTING'
+          | 'EMAIL_SECURITY'
+          | 'FW'
+          | 'FW_PG'
+          | 'HTTP'
+          | 'HTTP_CONTROL'
+          | 'HTTP_CRAWLER_REFERER'
+          | 'HTTP_ORIGINS'
+          | 'IQI'
+          | 'LEAKED_CREDENTIALS'
+          | 'NET'
+          | 'ROBOTS_TXT'
+          | 'SPEED'
+          | 'WORKERS_AI';
+
+        description: string;
+
+        endDate: string;
+
+        /**
+         * Event type for annotations.
+         */
+        eventType: 'EVENT' | 'GENERAL' | 'OUTAGE' | 'PARTIAL_PROJECTION' | 'PIPELINE' | 'TRAFFIC_ANOMALY';
+
+        /**
+         * Whether event is a single point in time or a time range.
+         */
+        isInstantaneous: boolean;
+
+        linkedUrl: string;
+
+        startDate: string;
+      }
+    }
+
+    export interface DateRange {
+      /**
+       * Adjusted end of date range.
+       */
+      endTime: string;
+
+      /**
+       * Adjusted start of date range.
+       */
+      startTime: string;
+    }
+
+    export interface Unit {
+      name: string;
+
+      value: string;
+    }
+  }
+
+  export interface unnamed_schema_ref_75bae70cf28e6bcef364b9840db3bdeb {
+    timestamps: Array<string>;
+
+    values: Array<string>;
+  }
+}
+
+export interface MarkdownForAgentSummaryParams {
+  /**
+   * End of the date range (inclusive).
+   */
+  dateEnd?: Array<string>;
+
+  /**
+   * Filters results by date range. For example, use `7d` and `7dcontrol` to compare
+   * this week with the previous week. Use this parameter or set specific start and
+   * end dates (`dateStart` and `dateEnd` parameters).
+   */
+  dateRange?: Array<string>;
+
+  /**
+   * Start of the date range.
+   */
+  dateStart?: Array<string>;
+
+  /**
+   * Format in which results will be returned.
+   */
+  format?: 'JSON' | 'CSV';
+
+  /**
+   * Array of names used to label the series in the response.
+   */
+  name?: Array<string>;
+}
+
+export interface MarkdownForAgentTimeseriesParams {
+  /**
+   * Aggregation interval of the results (e.g., in 15 minutes or 1 hour intervals).
+   * Refer to
+   * [Aggregation intervals](https://developers.cloudflare.com/radar/concepts/aggregation-intervals/).
+   */
+  aggInterval?: '15m' | '1h' | '1d' | '1w';
+
+  /**
+   * End of the date range (inclusive).
+   */
+  dateEnd?: Array<string>;
+
+  /**
+   * Filters results by date range. For example, use `7d` and `7dcontrol` to compare
+   * this week with the previous week. Use this parameter or set specific start and
+   * end dates (`dateStart` and `dateEnd` parameters).
+   */
+  dateRange?: Array<string>;
+
+  /**
+   * Start of the date range.
+   */
+  dateStart?: Array<string>;
+
+  /**
+   * Format in which results will be returned.
+   */
+  format?: 'JSON' | 'CSV';
+
+  /**
+   * Array of names used to label the series in the response.
+   */
+  name?: Array<string>;
+}
+
+export declare namespace MarkdownForAgents {
+  export {
+    type MarkdownForAgentSummaryResponse as MarkdownForAgentSummaryResponse,
+    type MarkdownForAgentTimeseriesResponse as MarkdownForAgentTimeseriesResponse,
+    type MarkdownForAgentSummaryParams as MarkdownForAgentSummaryParams,
+    type MarkdownForAgentTimeseriesParams as MarkdownForAgentTimeseriesParams,
+  };
+}

--- a/src/resources/radar/ai/to-markdown.ts
+++ b/src/resources/radar/ai/to-markdown.ts
@@ -13,7 +13,7 @@ export class ToMarkdown extends APIResource {
     params: ToMarkdownCreateParams,
     options?: Core.RequestOptions,
   ): Core.APIPromise<ToMarkdownCreateResponse[]> {
-    const { account_id, ...body } = params;
+    const { account_id = this._client.accountId, ...body } = params;
     return (
       this._client.post(
         `/accounts/${account_id}/ai/tomarkdown`,
@@ -39,7 +39,7 @@ export interface ToMarkdownCreateParams {
   /**
    * Path param
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param

--- a/src/resources/radar/index.ts
+++ b/src/resources/radar/index.ts
@@ -10,6 +10,11 @@ export {
   type AS112TimeseriesParams,
   type AS112TimeseriesGroupsV2Params,
 } from './as112/index';
+export {
+  AgentReadiness,
+  type AgentReadinessSummaryResponse,
+  type AgentReadinessSummaryParams,
+} from './agent-readiness';
 export { Annotations, type AnnotationListResponse, type AnnotationListParams } from './annotations/index';
 export { Attacks } from './attacks/index';
 export { BGP, type BGPTimeseriesResponse, type BGPTimeseriesParams } from './bgp/index';

--- a/src/resources/radar/radar.ts
+++ b/src/resources/radar/radar.ts
@@ -1,6 +1,12 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';
+import * as AgentReadinessAPI from './agent-readiness';
+import {
+  AgentReadiness,
+  AgentReadinessSummaryParams,
+  AgentReadinessSummaryResponse,
+} from './agent-readiness';
 import * as DatasetsAPI from './datasets';
 import {
   DatasetDownloadParams,
@@ -138,6 +144,7 @@ import * as VerifiedBotsAPI from './verified-bots/verified-bots';
 import { VerifiedBots } from './verified-bots/verified-bots';
 
 export class Radar extends APIResource {
+  agentReadiness: AgentReadinessAPI.AgentReadiness = new AgentReadinessAPI.AgentReadiness(this._client);
   ai: AIAPI.AI = new AIAPI.AI(this._client);
   ct: CTAPI.CT = new CTAPI.CT(this._client);
   annotations: AnnotationsAPI.Annotations = new AnnotationsAPI.Annotations(this._client);
@@ -169,6 +176,7 @@ export class Radar extends APIResource {
   );
 }
 
+Radar.AgentReadiness = AgentReadiness;
 Radar.AI = AI;
 Radar.CT = CT;
 Radar.Annotations = Annotations;
@@ -194,6 +202,12 @@ Radar.RobotsTXT = RobotsTXT;
 Radar.LeakedCredentials = LeakedCredentials;
 
 export declare namespace Radar {
+  export {
+    AgentReadiness as AgentReadiness,
+    type AgentReadinessSummaryResponse as AgentReadinessSummaryResponse,
+    type AgentReadinessSummaryParams as AgentReadinessSummaryParams,
+  };
+
   export { AI as AI };
 
   export {

--- a/src/resources/workers/account-settings.ts
+++ b/src/resources/workers/account-settings.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';
+import { isRequestOptions } from '../../core';
 import * as Core from '../../core';
 
 export class AccountSettings extends APIResource {
@@ -16,10 +17,18 @@ export class AccountSettings extends APIResource {
    * ```
    */
   update(
-    params: AccountSettingUpdateParams,
+    params?: AccountSettingUpdateParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<AccountSettingUpdateResponse>;
+  update(options?: Core.RequestOptions): Core.APIPromise<AccountSettingUpdateResponse>;
+  update(
+    params: AccountSettingUpdateParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<AccountSettingUpdateResponse> {
-    const { account_id, ...body } = params;
+    if (isRequestOptions(params)) {
+      return this.update({}, params);
+    }
+    const { account_id = this._client.accountId, ...body } = params;
     return (
       this._client.put(`/accounts/${account_id}/workers/account-settings`, {
         body,
@@ -40,10 +49,18 @@ export class AccountSettings extends APIResource {
    * ```
    */
   get(
-    params: AccountSettingGetParams,
+    params?: AccountSettingGetParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<AccountSettingGetResponse>;
+  get(options?: Core.RequestOptions): Core.APIPromise<AccountSettingGetResponse>;
+  get(
+    params: AccountSettingGetParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<AccountSettingGetResponse> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.get({}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return (
       this._client.get(`/accounts/${account_id}/workers/account-settings`, options) as Core.APIPromise<{
         result: AccountSettingGetResponse;
@@ -68,7 +85,7 @@ export interface AccountSettingUpdateParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param
@@ -85,7 +102,7 @@ export interface AccountSettingGetParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 export declare namespace AccountSettings {

--- a/src/resources/workers/assets/upload.ts
+++ b/src/resources/workers/assets/upload.ts
@@ -19,7 +19,7 @@ export class Upload extends APIResource {
    * ```
    */
   create(params: UploadCreateParams, options?: Core.RequestOptions): Core.APIPromise<UploadCreateResponse> {
-    const { account_id, base64, body } = params;
+    const { account_id = this._client.accountId, base64, body } = params;
     return (
       this._client.post(
         `/accounts/${account_id}/workers/assets/upload`,
@@ -40,7 +40,7 @@ export interface UploadCreateParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Query param: Whether the file contents are base64-encoded. Must be `true`.

--- a/src/resources/workers/beta/workers/versions.ts
+++ b/src/resources/workers/beta/workers/versions.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../../../resource';
+import { isRequestOptions } from '../../../../core';
 import * as Core from '../../../../core';
 import * as WorkersAPI from '../../workers';
 import { V4PagePaginationArray, type V4PagePaginationArrayParams } from '../../../../pagination';
@@ -23,7 +24,7 @@ export class Versions extends APIResource {
     params: VersionCreateParams,
     options?: Core.RequestOptions,
   ): Core.APIPromise<Version> {
-    const { account_id, deploy, ...body } = params;
+    const { account_id = this._client.accountId, deploy, ...body } = params;
     return (
       this._client.post(`/accounts/${account_id}/workers/workers/${workerId}/versions`, {
         query: { deploy },
@@ -49,10 +50,22 @@ export class Versions extends APIResource {
    */
   list(
     workerId: string,
-    params: VersionListParams,
+    params?: VersionListParams,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<VersionsV4PagePaginationArray, Version>;
+  list(
+    workerId: string,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<VersionsV4PagePaginationArray, Version>;
+  list(
+    workerId: string,
+    params: VersionListParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.PagePromise<VersionsV4PagePaginationArray, Version> {
-    const { account_id, ...query } = params;
+    if (isRequestOptions(params)) {
+      return this.list(workerId, {}, params);
+    }
+    const { account_id = this._client.accountId, ...query } = params;
     return this._client.getAPIList(
       `/accounts/${account_id}/workers/workers/${workerId}/versions`,
       VersionsV4PagePaginationArray,
@@ -76,10 +89,24 @@ export class Versions extends APIResource {
   delete(
     workerId: string,
     versionId: string,
-    params: VersionDeleteParams,
+    params?: VersionDeleteParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<VersionDeleteResponse>;
+  delete(
+    workerId: string,
+    versionId: string,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<VersionDeleteResponse>;
+  delete(
+    workerId: string,
+    versionId: string,
+    params: VersionDeleteParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<VersionDeleteResponse> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.delete(workerId, versionId, {}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return this._client.delete(
       `/accounts/${account_id}/workers/workers/${workerId}/versions/${versionId}`,
       options,
@@ -102,10 +129,20 @@ export class Versions extends APIResource {
   get(
     workerId: string,
     versionId: string,
-    params: VersionGetParams,
+    params?: VersionGetParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<Version>;
+  get(workerId: string, versionId: string, options?: Core.RequestOptions): Core.APIPromise<Version>;
+  get(
+    workerId: string,
+    versionId: string,
+    params: VersionGetParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<Version> {
-    const { account_id, ...query } = params;
+    if (isRequestOptions(params)) {
+      return this.get(workerId, versionId, {}, params);
+    }
+    const { account_id = this._client.accountId, ...query } = params;
     return (
       this._client.get(`/accounts/${account_id}/workers/workers/${workerId}/versions/${versionId}`, {
         query,
@@ -1295,7 +1332,7 @@ export interface VersionCreateParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Query param: If true, a deployment will be created that sends 100% of traffic to
@@ -2426,21 +2463,21 @@ export interface VersionListParams extends V4PagePaginationArrayParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 export interface VersionDeleteParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 export interface VersionGetParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Query param: Whether to include the `modules` property of the version in the

--- a/src/resources/workers/beta/workers/workers.ts
+++ b/src/resources/workers/beta/workers/workers.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../../../resource';
+import { isRequestOptions } from '../../../../core';
 import * as Core from '../../../../core';
 import * as VersionsAPI from './versions';
 import {
@@ -30,7 +31,7 @@ export class Workers extends APIResource {
    * ```
    */
   create(params: WorkerCreateParams, options?: Core.RequestOptions): Core.APIPromise<Worker> {
-    const { account_id, ...body } = params;
+    const { account_id = this._client.accountId, ...body } = params;
     return (
       this._client.post(`/accounts/${account_id}/workers/workers`, { body, ...options }) as Core.APIPromise<{
         result: Worker;
@@ -60,7 +61,7 @@ export class Workers extends APIResource {
     params: WorkerUpdateParams,
     options?: Core.RequestOptions,
   ): Core.APIPromise<Worker> {
-    const { account_id, ...body } = params;
+    const { account_id = this._client.accountId, ...body } = params;
     return (
       this._client.put(`/accounts/${account_id}/workers/workers/${workerId}`, {
         body,
@@ -83,10 +84,18 @@ export class Workers extends APIResource {
    * ```
    */
   list(
-    params: WorkerListParams,
+    params?: WorkerListParams,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<WorkersV4PagePaginationArray, Worker>;
+  list(options?: Core.RequestOptions): Core.PagePromise<WorkersV4PagePaginationArray, Worker>;
+  list(
+    params: WorkerListParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.PagePromise<WorkersV4PagePaginationArray, Worker> {
-    const { account_id, ...query } = params;
+    if (isRequestOptions(params)) {
+      return this.list({}, params);
+    }
+    const { account_id = this._client.accountId, ...query } = params;
     return this._client.getAPIList(`/accounts/${account_id}/workers/workers`, WorkersV4PagePaginationArray, {
       query,
       ...options,
@@ -106,10 +115,19 @@ export class Workers extends APIResource {
    */
   delete(
     workerId: string,
-    params: WorkerDeleteParams,
+    params?: WorkerDeleteParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<WorkerDeleteResponse>;
+  delete(workerId: string, options?: Core.RequestOptions): Core.APIPromise<WorkerDeleteResponse>;
+  delete(
+    workerId: string,
+    params: WorkerDeleteParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<WorkerDeleteResponse> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.delete(workerId, {}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return this._client.delete(`/accounts/${account_id}/workers/workers/${workerId}`, options);
   }
 
@@ -134,7 +152,7 @@ export class Workers extends APIResource {
    * ```
    */
   edit(workerId: string, params: WorkerEditParams, options?: Core.RequestOptions): Core.APIPromise<Worker> {
-    const { account_id, ...body } = params;
+    const { account_id = this._client.accountId, ...body } = params;
     return (
       this._client.patch(`/accounts/${account_id}/workers/workers/${workerId}`, {
         body,
@@ -154,8 +172,17 @@ export class Workers extends APIResource {
    * );
    * ```
    */
-  get(workerId: string, params: WorkerGetParams, options?: Core.RequestOptions): Core.APIPromise<Worker> {
-    const { account_id } = params;
+  get(workerId: string, params?: WorkerGetParams, options?: Core.RequestOptions): Core.APIPromise<Worker>;
+  get(workerId: string, options?: Core.RequestOptions): Core.APIPromise<Worker>;
+  get(
+    workerId: string,
+    params: WorkerGetParams | Core.RequestOptions = {},
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<Worker> {
+    if (isRequestOptions(params)) {
+      return this.get(workerId, {}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return (
       this._client.get(`/accounts/${account_id}/workers/workers/${workerId}`, options) as Core.APIPromise<{
         result: Worker;
@@ -516,7 +543,7 @@ export interface WorkerCreateParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param: Name of the Worker.
@@ -663,7 +690,7 @@ export interface WorkerUpdateParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param: Name of the Worker.
@@ -810,7 +837,7 @@ export interface WorkerListParams extends V4PagePaginationArrayParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Query param: Sort direction.
@@ -827,14 +854,14 @@ export interface WorkerDeleteParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 export interface WorkerEditParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param: Whether logpush is enabled for the Worker.
@@ -981,7 +1008,7 @@ export interface WorkerGetParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 Workers.WorkersV4PagePaginationArray = WorkersV4PagePaginationArray;

--- a/src/resources/workers/domains.ts
+++ b/src/resources/workers/domains.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';
+import { isRequestOptions } from '../../core';
 import * as Core from '../../core';
 import { SinglePage } from '../../pagination';
 
@@ -18,7 +19,7 @@ export class Domains extends APIResource {
    * ```
    */
   update(params: DomainUpdateParams, options?: Core.RequestOptions): Core.APIPromise<DomainUpdateResponse> {
-    const { account_id, ...body } = params;
+    const { account_id = this._client.accountId, ...body } = params;
     return (
       this._client.put(`/accounts/${account_id}/workers/domains`, { body, ...options }) as Core.APIPromise<{
         result: DomainUpdateResponse;
@@ -40,10 +41,18 @@ export class Domains extends APIResource {
    * ```
    */
   list(
-    params: DomainListParams,
+    params?: DomainListParams,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<DomainListResponsesSinglePage, DomainListResponse>;
+  list(options?: Core.RequestOptions): Core.PagePromise<DomainListResponsesSinglePage, DomainListResponse>;
+  list(
+    params: DomainListParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.PagePromise<DomainListResponsesSinglePage, DomainListResponse> {
-    const { account_id, ...query } = params;
+    if (isRequestOptions(params)) {
+      return this.list({}, params);
+    }
+    const { account_id = this._client.accountId, ...query } = params;
     return this._client.getAPIList(`/accounts/${account_id}/workers/domains`, DomainListResponsesSinglePage, {
       query,
       ...options,
@@ -64,10 +73,19 @@ export class Domains extends APIResource {
    */
   delete(
     domainId: string,
-    params: DomainDeleteParams,
+    params?: DomainDeleteParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<DomainDeleteResponse>;
+  delete(domainId: string, options?: Core.RequestOptions): Core.APIPromise<DomainDeleteResponse>;
+  delete(
+    domainId: string,
+    params: DomainDeleteParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<DomainDeleteResponse> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.delete(domainId, {}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return this._client.delete(`/accounts/${account_id}/workers/domains/${domainId}`, options);
   }
 
@@ -84,10 +102,19 @@ export class Domains extends APIResource {
    */
   get(
     domainId: string,
-    params: DomainGetParams,
+    params?: DomainGetParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<DomainGetResponse>;
+  get(domainId: string, options?: Core.RequestOptions): Core.APIPromise<DomainGetResponse>;
+  get(
+    domainId: string,
+    params: DomainGetParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<DomainGetResponse> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.get(domainId, {}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return (
       this._client.get(`/accounts/${account_id}/workers/domains/${domainId}`, options) as Core.APIPromise<{
         result: DomainGetResponse;
@@ -264,7 +291,7 @@ export interface DomainUpdateParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param: Hostname of the domain. Can be either the zone apex or a subdomain
@@ -298,7 +325,7 @@ export interface DomainListParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Query param: Worker environment associated with the domain.
@@ -330,14 +357,14 @@ export interface DomainDeleteParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 export interface DomainGetParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 Domains.DomainListResponsesSinglePage = DomainListResponsesSinglePage;

--- a/src/resources/workers/observability/destinations.ts
+++ b/src/resources/workers/observability/destinations.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../../resource';
+import { isRequestOptions } from '../../../core';
 import * as Core from '../../../core';
 import { SinglePage } from '../../../pagination';
 
@@ -28,7 +29,7 @@ export class Destinations extends APIResource {
     params: DestinationCreateParams,
     options?: Core.RequestOptions,
   ): Core.APIPromise<DestinationCreateResponse> {
-    const { account_id, ...body } = params;
+    const { account_id = this._client.accountId, ...body } = params;
     return (
       this._client.post(`/accounts/${account_id}/workers/observability/destinations`, {
         body,
@@ -62,7 +63,7 @@ export class Destinations extends APIResource {
     params: DestinationUpdateParams,
     options?: Core.RequestOptions,
   ): Core.APIPromise<DestinationUpdateResponse> {
-    const { account_id, ...body } = params;
+    const { account_id = this._client.accountId, ...body } = params;
     return (
       this._client.patch(`/accounts/${account_id}/workers/observability/destinations/${slug}`, {
         body,
@@ -85,10 +86,20 @@ export class Destinations extends APIResource {
    * ```
    */
   list(
-    params: DestinationListParams,
+    params?: DestinationListParams,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<DestinationListResponsesSinglePage, DestinationListResponse>;
+  list(
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<DestinationListResponsesSinglePage, DestinationListResponse>;
+  list(
+    params: DestinationListParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.PagePromise<DestinationListResponsesSinglePage, DestinationListResponse> {
-    const { account_id, ...query } = params;
+    if (isRequestOptions(params)) {
+      return this.list({}, params);
+    }
+    const { account_id = this._client.accountId, ...query } = params;
     return this._client.getAPIList(
       `/accounts/${account_id}/workers/observability/destinations`,
       DestinationListResponsesSinglePage,
@@ -110,10 +121,19 @@ export class Destinations extends APIResource {
    */
   delete(
     slug: string,
-    params: DestinationDeleteParams,
+    params?: DestinationDeleteParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<DestinationDeleteResponse>;
+  delete(slug: string, options?: Core.RequestOptions): Core.APIPromise<DestinationDeleteResponse>;
+  delete(
+    slug: string,
+    params: DestinationDeleteParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<DestinationDeleteResponse> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.delete(slug, {}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return (
       this._client.delete(
         `/accounts/${account_id}/workers/observability/destinations/${slug}`,
@@ -245,7 +265,7 @@ export interface DestinationCreateParams {
   /**
    * Path param: Your Cloudflare account ID.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param
@@ -284,7 +304,7 @@ export interface DestinationUpdateParams {
   /**
    * Path param: Your Cloudflare account ID.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param
@@ -311,7 +331,7 @@ export interface DestinationListParams {
   /**
    * Path param: Your Cloudflare account ID.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Query param
@@ -338,7 +358,7 @@ export interface DestinationDeleteParams {
   /**
    * Your Cloudflare account ID.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 Destinations.DestinationListResponsesSinglePage = DestinationListResponsesSinglePage;

--- a/src/resources/workers/observability/telemetry.ts
+++ b/src/resources/workers/observability/telemetry.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../../resource';
+import { isRequestOptions } from '../../../core';
 import * as Core from '../../../core';
 import { SinglePage } from '../../../pagination';
 
@@ -19,10 +20,20 @@ export class Telemetry extends APIResource {
    * ```
    */
   keys(
-    params: TelemetryKeysParams,
+    params?: TelemetryKeysParams,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<TelemetryKeysResponsesSinglePage, TelemetryKeysResponse>;
+  keys(
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<TelemetryKeysResponsesSinglePage, TelemetryKeysResponse>;
+  keys(
+    params: TelemetryKeysParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.PagePromise<TelemetryKeysResponsesSinglePage, TelemetryKeysResponse> {
-    const { account_id, ...body } = params;
+    if (isRequestOptions(params)) {
+      return this.keys({}, params);
+    }
+    const { account_id = this._client.accountId, ...body } = params;
     return this._client.getAPIList(
       `/accounts/${account_id}/workers/observability/telemetry/keys`,
       TelemetryKeysResponsesSinglePage,
@@ -47,7 +58,7 @@ export class Telemetry extends APIResource {
     params: TelemetryQueryParams,
     options?: Core.RequestOptions,
   ): Core.APIPromise<TelemetryQueryResponse> {
-    const { account_id, ...body } = params;
+    const { account_id = this._client.accountId, ...body } = params;
     return (
       this._client.post(`/accounts/${account_id}/workers/observability/telemetry/query`, {
         body,
@@ -79,7 +90,7 @@ export class Telemetry extends APIResource {
     params: TelemetryValuesParams,
     options?: Core.RequestOptions,
   ): Core.PagePromise<TelemetryValuesResponsesSinglePage, TelemetryValuesResponse> {
-    const { account_id, ...body } = params;
+    const { account_id = this._client.accountId, ...body } = params;
     return this._client.getAPIList(
       `/accounts/${account_id}/workers/observability/telemetry/values`,
       TelemetryValuesResponsesSinglePage,
@@ -1105,7 +1116,7 @@ export interface TelemetryKeysParams {
   /**
    * Path param: Your Cloudflare account ID.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param: Leave this empty to use the default datasets
@@ -1242,7 +1253,7 @@ export interface TelemetryQueryParams {
   /**
    * Path param: Your Cloudflare account ID.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param: Unique identifier for the query to execute
@@ -1555,7 +1566,7 @@ export interface TelemetryValuesParams {
   /**
    * Path param: Your Cloudflare account ID.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param: Leave this empty to use the default datasets

--- a/src/resources/workers/routes.ts
+++ b/src/resources/workers/routes.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';
+import { isRequestOptions } from '../../core';
 import * as Core from '../../core';
 import { SinglePage } from '../../pagination';
 
@@ -17,7 +18,7 @@ export class Routes extends APIResource {
    * ```
    */
   create(params: RouteCreateParams, options?: Core.RequestOptions): Core.APIPromise<RouteCreateResponse> {
-    const { zone_id, ...body } = params;
+    const { zone_id = this._client.zoneId, ...body } = params;
     return (
       this._client.post(`/zones/${zone_id}/workers/routes`, { body, ...options }) as Core.APIPromise<{
         result: RouteCreateResponse;
@@ -44,7 +45,7 @@ export class Routes extends APIResource {
     params: RouteUpdateParams,
     options?: Core.RequestOptions,
   ): Core.APIPromise<RouteUpdateResponse> {
-    const { zone_id, ...body } = params;
+    const { zone_id = this._client.zoneId, ...body } = params;
     return (
       this._client.put(`/zones/${zone_id}/workers/routes/${routeId}`, {
         body,
@@ -67,10 +68,18 @@ export class Routes extends APIResource {
    * ```
    */
   list(
-    params: RouteListParams,
+    params?: RouteListParams,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<RouteListResponsesSinglePage, RouteListResponse>;
+  list(options?: Core.RequestOptions): Core.PagePromise<RouteListResponsesSinglePage, RouteListResponse>;
+  list(
+    params: RouteListParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.PagePromise<RouteListResponsesSinglePage, RouteListResponse> {
-    const { zone_id } = params;
+    if (isRequestOptions(params)) {
+      return this.list({}, params);
+    }
+    const { zone_id = this._client.zoneId } = params;
     return this._client.getAPIList(`/zones/${zone_id}/workers/routes`, RouteListResponsesSinglePage, options);
   }
 
@@ -87,10 +96,19 @@ export class Routes extends APIResource {
    */
   delete(
     routeId: string,
-    params: RouteDeleteParams,
+    params?: RouteDeleteParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<RouteDeleteResponse>;
+  delete(routeId: string, options?: Core.RequestOptions): Core.APIPromise<RouteDeleteResponse>;
+  delete(
+    routeId: string,
+    params: RouteDeleteParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<RouteDeleteResponse> {
-    const { zone_id } = params;
+    if (isRequestOptions(params)) {
+      return this.delete(routeId, {}, params);
+    }
+    const { zone_id = this._client.zoneId } = params;
     return (
       this._client.delete(`/zones/${zone_id}/workers/routes/${routeId}`, options) as Core.APIPromise<{
         result: RouteDeleteResponse;
@@ -111,10 +129,19 @@ export class Routes extends APIResource {
    */
   get(
     routeId: string,
-    params: RouteGetParams,
+    params?: RouteGetParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<RouteGetResponse>;
+  get(routeId: string, options?: Core.RequestOptions): Core.APIPromise<RouteGetResponse>;
+  get(
+    routeId: string,
+    params: RouteGetParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<RouteGetResponse> {
-    const { zone_id } = params;
+    if (isRequestOptions(params)) {
+      return this.get(routeId, {}, params);
+    }
+    const { zone_id = this._client.zoneId } = params;
     return (
       this._client.get(`/zones/${zone_id}/workers/routes/${routeId}`, options) as Core.APIPromise<{
         result: RouteGetResponse;
@@ -208,7 +235,7 @@ export interface RouteCreateParams {
   /**
    * Path param: Identifier.
    */
-  zone_id: string;
+  zone_id?: string;
 
   /**
    * Body param: Pattern to match incoming requests against.
@@ -226,7 +253,7 @@ export interface RouteUpdateParams {
   /**
    * Path param: Identifier.
    */
-  zone_id: string;
+  zone_id?: string;
 
   /**
    * Body param: Pattern to match incoming requests against.
@@ -244,21 +271,21 @@ export interface RouteListParams {
   /**
    * Identifier.
    */
-  zone_id: string;
+  zone_id?: string;
 }
 
 export interface RouteDeleteParams {
   /**
    * Identifier.
    */
-  zone_id: string;
+  zone_id?: string;
 }
 
 export interface RouteGetParams {
   /**
    * Identifier.
    */
-  zone_id: string;
+  zone_id?: string;
 }
 
 Routes.RouteListResponsesSinglePage = RouteListResponsesSinglePage;

--- a/src/resources/workers/scripts/assets/upload.ts
+++ b/src/resources/workers/scripts/assets/upload.ts
@@ -26,7 +26,7 @@ export class Upload extends APIResource {
     params: UploadCreateParams,
     options?: Core.RequestOptions,
   ): Core.APIPromise<UploadCreateResponse> {
-    const { account_id, ...body } = params;
+    const { account_id = this._client.accountId, ...body } = params;
     return (
       this._client.post(`/accounts/${account_id}/workers/scripts/${scriptName}/assets-upload-session`, {
         body,
@@ -52,7 +52,7 @@ export interface UploadCreateParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param: A manifest ([path]: {hash, size}) map of files to upload. As an

--- a/src/resources/workers/scripts/content.ts
+++ b/src/resources/workers/scripts/content.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../../resource';
+import { isRequestOptions } from '../../../core';
 import * as Core from '../../../core';
 import * as ScriptsAPI from './scripts';
 import { type Response } from '../../../_shims/index';
@@ -26,7 +27,7 @@ export class Content extends APIResource {
     options?: Core.RequestOptions,
   ): Core.APIPromise<ScriptsAPI.Script> {
     const {
-      account_id,
+      account_id = this._client.accountId,
       'CF-WORKER-BODY-PART': cfWorkerBodyPart,
       'CF-WORKER-MAIN-MODULE-PART': cfWorkerMainModulePart,
       ...body
@@ -66,10 +67,19 @@ export class Content extends APIResource {
    */
   get(
     scriptName: string,
-    params: ContentGetParams,
+    params?: ContentGetParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<Response>;
+  get(scriptName: string, options?: Core.RequestOptions): Core.APIPromise<Response>;
+  get(
+    scriptName: string,
+    params: ContentGetParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<Response> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.get(scriptName, {}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return this._client.get(`/accounts/${account_id}/workers/scripts/${scriptName}/content/v2`, {
       ...options,
       headers: { Accept: 'string', ...options?.headers },
@@ -82,7 +92,7 @@ export interface ContentUpdateParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param: JSON-encoded metadata about the uploaded parts and Worker
@@ -137,7 +147,7 @@ export interface ContentGetParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 export declare namespace Content {

--- a/src/resources/workers/scripts/deployments.ts
+++ b/src/resources/workers/scripts/deployments.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../../resource';
+import { isRequestOptions } from '../../../core';
 import * as Core from '../../../core';
 
 export class Deployments extends APIResource {
@@ -34,7 +35,7 @@ export class Deployments extends APIResource {
     params: DeploymentCreateParams,
     options?: Core.RequestOptions,
   ): Core.APIPromise<Deployment> {
-    const { account_id, force, ...body } = params;
+    const { account_id = this._client.accountId, force, ...body } = params;
     return (
       this._client.post(`/accounts/${account_id}/workers/scripts/${scriptName}/deployments`, {
         query: { force },
@@ -59,10 +60,19 @@ export class Deployments extends APIResource {
    */
   list(
     scriptName: string,
-    params: DeploymentListParams,
+    params?: DeploymentListParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<DeploymentListResponse>;
+  list(scriptName: string, options?: Core.RequestOptions): Core.APIPromise<DeploymentListResponse>;
+  list(
+    scriptName: string,
+    params: DeploymentListParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<DeploymentListResponse> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.list(scriptName, {}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return (
       this._client.get(
         `/accounts/${account_id}/workers/scripts/${scriptName}/deployments`,
@@ -88,10 +98,24 @@ export class Deployments extends APIResource {
   delete(
     scriptName: string,
     deploymentId: string,
-    params: DeploymentDeleteParams,
+    params?: DeploymentDeleteParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<DeploymentDeleteResponse>;
+  delete(
+    scriptName: string,
+    deploymentId: string,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<DeploymentDeleteResponse>;
+  delete(
+    scriptName: string,
+    deploymentId: string,
+    params: DeploymentDeleteParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<DeploymentDeleteResponse> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.delete(scriptName, deploymentId, {}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return this._client.delete(
       `/accounts/${account_id}/workers/scripts/${scriptName}/deployments/${deploymentId}`,
       options,
@@ -114,10 +138,20 @@ export class Deployments extends APIResource {
   get(
     scriptName: string,
     deploymentId: string,
-    params: DeploymentGetParams,
+    params?: DeploymentGetParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<Deployment>;
+  get(scriptName: string, deploymentId: string, options?: Core.RequestOptions): Core.APIPromise<Deployment>;
+  get(
+    scriptName: string,
+    deploymentId: string,
+    params: DeploymentGetParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<Deployment> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.get(scriptName, deploymentId, {}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return (
       this._client.get(
         `/accounts/${account_id}/workers/scripts/${scriptName}/deployments/${deploymentId}`,
@@ -216,7 +250,7 @@ export interface DeploymentCreateParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param
@@ -260,21 +294,21 @@ export interface DeploymentListParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 export interface DeploymentDeleteParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 export interface DeploymentGetParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 export declare namespace Deployments {

--- a/src/resources/workers/scripts/schedules.ts
+++ b/src/resources/workers/scripts/schedules.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../../resource';
+import { isRequestOptions } from '../../../core';
 import * as Core from '../../../core';
 
 export class Schedules extends APIResource {
@@ -24,7 +25,7 @@ export class Schedules extends APIResource {
     params: ScheduleUpdateParams,
     options?: Core.RequestOptions,
   ): Core.APIPromise<ScheduleUpdateResponse> {
-    const { account_id, body } = params;
+    const { account_id = this._client.accountId, body } = params;
     return (
       this._client.put(`/accounts/${account_id}/workers/scripts/${scriptName}/schedules`, {
         body: body,
@@ -46,10 +47,19 @@ export class Schedules extends APIResource {
    */
   get(
     scriptName: string,
-    params: ScheduleGetParams,
+    params?: ScheduleGetParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<ScheduleGetResponse>;
+  get(scriptName: string, options?: Core.RequestOptions): Core.APIPromise<ScheduleGetResponse>;
+  get(
+    scriptName: string,
+    params: ScheduleGetParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<ScheduleGetResponse> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.get(scriptName, {}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return (
       this._client.get(
         `/accounts/${account_id}/workers/scripts/${scriptName}/schedules`,
@@ -91,7 +101,7 @@ export interface ScheduleUpdateParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param
@@ -109,7 +119,7 @@ export interface ScheduleGetParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 export declare namespace Schedules {

--- a/src/resources/workers/scripts/script-and-version-settings.ts
+++ b/src/resources/workers/scripts/script-and-version-settings.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../../resource';
+import { isRequestOptions } from '../../../core';
 import * as Core from '../../../core';
 import * as WorkersAPI from '../workers';
 import * as TailAPI from './tail';
@@ -23,7 +24,7 @@ export class ScriptAndVersionSettings extends APIResource {
     params: ScriptAndVersionSettingEditParams,
     options?: Core.RequestOptions,
   ): Core.APIPromise<ScriptAndVersionSettingEditResponse> {
-    const { account_id, ...body } = params;
+    const { account_id = this._client.accountId, ...body } = params;
     return (
       this._client.patch(
         `/accounts/${account_id}/workers/scripts/${scriptName}/settings`,
@@ -46,10 +47,19 @@ export class ScriptAndVersionSettings extends APIResource {
    */
   get(
     scriptName: string,
-    params: ScriptAndVersionSettingGetParams,
+    params?: ScriptAndVersionSettingGetParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<ScriptAndVersionSettingGetResponse>;
+  get(scriptName: string, options?: Core.RequestOptions): Core.APIPromise<ScriptAndVersionSettingGetResponse>;
+  get(
+    scriptName: string,
+    params: ScriptAndVersionSettingGetParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<ScriptAndVersionSettingGetResponse> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.get(scriptName, {}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return (
       this._client.get(
         `/accounts/${account_id}/workers/scripts/${scriptName}/settings`,
@@ -2227,7 +2237,7 @@ export interface ScriptAndVersionSettingEditParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param
@@ -3357,7 +3367,7 @@ export interface ScriptAndVersionSettingGetParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 export declare namespace ScriptAndVersionSettings {

--- a/src/resources/workers/scripts/scripts.ts
+++ b/src/resources/workers/scripts/scripts.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../../resource';
+import { isRequestOptions } from '../../../core';
 import * as Core from '../../../core';
 import * as WorkersAPI from '../workers';
 import * as ContentAPI from './content';
@@ -117,7 +118,7 @@ export class Scripts extends APIResource {
     params: ScriptUpdateParams,
     options?: Core.RequestOptions,
   ): Core.APIPromise<ScriptUpdateResponse> {
-    const { account_id, bindings_inherit, ...body } = params;
+    const { account_id = this._client.accountId, bindings_inherit, ...body } = params;
     return (
       this._client.put(
         `/accounts/${account_id}/workers/scripts/${scriptName}`,
@@ -146,10 +147,18 @@ export class Scripts extends APIResource {
    * ```
    */
   list(
-    params: ScriptListParams,
+    params?: ScriptListParams,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<ScriptListResponsesSinglePage, ScriptListResponse>;
+  list(options?: Core.RequestOptions): Core.PagePromise<ScriptListResponsesSinglePage, ScriptListResponse>;
+  list(
+    params: ScriptListParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.PagePromise<ScriptListResponsesSinglePage, ScriptListResponse> {
-    const { account_id, ...query } = params;
+    if (isRequestOptions(params)) {
+      return this.list({}, params);
+    }
+    const { account_id = this._client.accountId, ...query } = params;
     return this._client.getAPIList(`/accounts/${account_id}/workers/scripts`, ScriptListResponsesSinglePage, {
       query,
       ...options,
@@ -169,10 +178,19 @@ export class Scripts extends APIResource {
    */
   delete(
     scriptName: string,
-    params: ScriptDeleteParams,
+    params?: ScriptDeleteParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<ScriptDeleteResponse | null>;
+  delete(scriptName: string, options?: Core.RequestOptions): Core.APIPromise<ScriptDeleteResponse | null>;
+  delete(
+    scriptName: string,
+    params: ScriptDeleteParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<ScriptDeleteResponse | null> {
-    const { account_id, force } = params;
+    if (isRequestOptions(params)) {
+      return this.delete(scriptName, {}, params);
+    }
+    const { account_id = this._client.accountId, force } = params;
     return (
       this._client.delete(`/accounts/${account_id}/workers/scripts/${scriptName}`, {
         query: { force },
@@ -193,8 +211,17 @@ export class Scripts extends APIResource {
    * );
    * ```
    */
-  get(scriptName: string, params: ScriptGetParams, options?: Core.RequestOptions): Core.APIPromise<string> {
-    const { account_id } = params;
+  get(scriptName: string, params?: ScriptGetParams, options?: Core.RequestOptions): Core.APIPromise<string>;
+  get(scriptName: string, options?: Core.RequestOptions): Core.APIPromise<string>;
+  get(
+    scriptName: string,
+    params: ScriptGetParams | Core.RequestOptions = {},
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<string> {
+    if (isRequestOptions(params)) {
+      return this.get(scriptName, {}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return this._client.get(`/accounts/${account_id}/workers/scripts/${scriptName}`, {
       ...options,
       headers: { Accept: 'application/javascript', ...options?.headers },
@@ -211,8 +238,16 @@ export class Scripts extends APIResource {
    * });
    * ```
    */
-  search(params: ScriptSearchParams, options?: Core.RequestOptions): Core.APIPromise<ScriptSearchResponse> {
-    const { account_id, ...query } = params;
+  search(params?: ScriptSearchParams, options?: Core.RequestOptions): Core.APIPromise<ScriptSearchResponse>;
+  search(options?: Core.RequestOptions): Core.APIPromise<ScriptSearchResponse>;
+  search(
+    params: ScriptSearchParams | Core.RequestOptions = {},
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<ScriptSearchResponse> {
+    if (isRequestOptions(params)) {
+      return this.search({}, params);
+    }
+    const { account_id = this._client.accountId, ...query } = params;
     return (
       this._client.get(`/accounts/${account_id}/workers/scripts-search`, {
         query,
@@ -1666,7 +1701,7 @@ export interface ScriptUpdateParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param: JSON-encoded metadata about the uploaded parts and Worker
@@ -2902,7 +2937,7 @@ export interface ScriptListParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Query param: Filter scripts by tags. Format: comma-separated list of tag:allowed
@@ -2915,7 +2950,7 @@ export interface ScriptDeleteParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Query param: If set to true, delete will not be stopped by associated service
@@ -2929,14 +2964,14 @@ export interface ScriptGetParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 export interface ScriptSearchParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Query param: Worker ID (also called tag) to search for. Only exact matches are

--- a/src/resources/workers/scripts/secrets.ts
+++ b/src/resources/workers/scripts/secrets.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../../resource';
+import { isRequestOptions } from '../../../core';
 import * as Core from '../../../core';
 import { SinglePage } from '../../../pagination';
 
@@ -26,7 +27,7 @@ export class Secrets extends APIResource {
     params: SecretUpdateParams,
     options?: Core.RequestOptions,
   ): Core.APIPromise<SecretUpdateResponse> {
-    const { account_id, ...body } = params;
+    const { account_id = this._client.accountId, ...body } = params;
     return (
       this._client.put(`/accounts/${account_id}/workers/scripts/${scriptName}/secrets`, {
         body,
@@ -51,10 +52,22 @@ export class Secrets extends APIResource {
    */
   list(
     scriptName: string,
-    params: SecretListParams,
+    params?: SecretListParams,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<SecretListResponsesSinglePage, SecretListResponse>;
+  list(
+    scriptName: string,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<SecretListResponsesSinglePage, SecretListResponse>;
+  list(
+    scriptName: string,
+    params: SecretListParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.PagePromise<SecretListResponsesSinglePage, SecretListResponse> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.list(scriptName, {}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return this._client.getAPIList(
       `/accounts/${account_id}/workers/scripts/${scriptName}/secrets`,
       SecretListResponsesSinglePage,
@@ -77,10 +90,24 @@ export class Secrets extends APIResource {
   delete(
     scriptName: string,
     secretName: string,
-    params: SecretDeleteParams,
+    params?: SecretDeleteParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<SecretDeleteResponse | null>;
+  delete(
+    scriptName: string,
+    secretName: string,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<SecretDeleteResponse | null>;
+  delete(
+    scriptName: string,
+    secretName: string,
+    params: SecretDeleteParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<SecretDeleteResponse | null> {
-    const { account_id, url_encoded } = params;
+    if (isRequestOptions(params)) {
+      return this.delete(scriptName, secretName, {}, params);
+    }
+    const { account_id = this._client.accountId, url_encoded } = params;
     return (
       this._client.delete(`/accounts/${account_id}/workers/scripts/${scriptName}/secrets/${secretName}`, {
         query: { url_encoded },
@@ -104,10 +131,24 @@ export class Secrets extends APIResource {
   get(
     scriptName: string,
     secretName: string,
-    params: SecretGetParams,
+    params?: SecretGetParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<SecretGetResponse>;
+  get(
+    scriptName: string,
+    secretName: string,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<SecretGetResponse>;
+  get(
+    scriptName: string,
+    secretName: string,
+    params: SecretGetParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<SecretGetResponse> {
-    const { account_id, ...query } = params;
+    if (isRequestOptions(params)) {
+      return this.get(scriptName, secretName, {}, params);
+    }
+    const { account_id = this._client.accountId, ...query } = params;
     return (
       this._client.get(`/accounts/${account_id}/workers/scripts/${scriptName}/secrets/${secretName}`, {
         query,
@@ -289,7 +330,7 @@ export declare namespace SecretUpdateParams {
     /**
      * Path param: Identifier.
      */
-    account_id: string;
+    account_id?: string;
 
     /**
      * Body param: A JavaScript variable name for the binding.
@@ -311,7 +352,7 @@ export declare namespace SecretUpdateParams {
     /**
      * Path param: Identifier.
      */
-    account_id: string;
+    account_id?: string;
 
     /**
      * Body param: Algorithm-specific key parameters.
@@ -362,14 +403,14 @@ export interface SecretListParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 export interface SecretDeleteParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Query param: Flag that indicates whether the secret name is URL encoded.
@@ -381,7 +422,7 @@ export interface SecretGetParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Query param: Flag that indicates whether the secret name is URL encoded.

--- a/src/resources/workers/scripts/settings.ts
+++ b/src/resources/workers/scripts/settings.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../../resource';
+import { isRequestOptions } from '../../../core';
 import * as Core from '../../../core';
 import * as ScriptsAPI from './scripts';
 import * as TailAPI from './tail';
@@ -25,7 +26,7 @@ export class Settings extends APIResource {
     params: SettingEditParams,
     options?: Core.RequestOptions,
   ): Core.APIPromise<ScriptsAPI.ScriptSetting> {
-    const { account_id, ...body } = params;
+    const { account_id = this._client.accountId, ...body } = params;
     return (
       this._client.patch(`/accounts/${account_id}/workers/scripts/${scriptName}/script-settings`, {
         body,
@@ -50,10 +51,19 @@ export class Settings extends APIResource {
    */
   get(
     scriptName: string,
-    params: SettingGetParams,
+    params?: SettingGetParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<ScriptsAPI.ScriptSetting>;
+  get(scriptName: string, options?: Core.RequestOptions): Core.APIPromise<ScriptsAPI.ScriptSetting>;
+  get(
+    scriptName: string,
+    params: SettingGetParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<ScriptsAPI.ScriptSetting> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.get(scriptName, {}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return (
       this._client.get(
         `/accounts/${account_id}/workers/scripts/${scriptName}/script-settings`,
@@ -67,7 +77,7 @@ export interface SettingEditParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param: Whether Logpush is turned on for the Worker.
@@ -181,7 +191,7 @@ export interface SettingGetParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 export declare namespace Settings {

--- a/src/resources/workers/scripts/subdomain.ts
+++ b/src/resources/workers/scripts/subdomain.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../../resource';
+import { isRequestOptions } from '../../../core';
 import * as Core from '../../../core';
 
 export class Subdomain extends APIResource {
@@ -24,7 +25,7 @@ export class Subdomain extends APIResource {
     params: SubdomainCreateParams,
     options?: Core.RequestOptions,
   ): Core.APIPromise<SubdomainCreateResponse> {
-    const { account_id, ...body } = params;
+    const { account_id = this._client.accountId, ...body } = params;
     return (
       this._client.post(`/accounts/${account_id}/workers/scripts/${scriptName}/subdomain`, {
         body,
@@ -47,10 +48,19 @@ export class Subdomain extends APIResource {
    */
   delete(
     scriptName: string,
-    params: SubdomainDeleteParams,
+    params?: SubdomainDeleteParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<SubdomainDeleteResponse>;
+  delete(scriptName: string, options?: Core.RequestOptions): Core.APIPromise<SubdomainDeleteResponse>;
+  delete(
+    scriptName: string,
+    params: SubdomainDeleteParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<SubdomainDeleteResponse> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.delete(scriptName, {}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return (
       this._client.delete(
         `/accounts/${account_id}/workers/scripts/${scriptName}/subdomain`,
@@ -73,10 +83,19 @@ export class Subdomain extends APIResource {
    */
   get(
     scriptName: string,
-    params: SubdomainGetParams,
+    params?: SubdomainGetParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<SubdomainGetResponse>;
+  get(scriptName: string, options?: Core.RequestOptions): Core.APIPromise<SubdomainGetResponse>;
+  get(
+    scriptName: string,
+    params: SubdomainGetParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<SubdomainGetResponse> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.get(scriptName, {}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return (
       this._client.get(
         `/accounts/${account_id}/workers/scripts/${scriptName}/subdomain`,
@@ -126,7 +145,7 @@ export interface SubdomainCreateParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param: Whether the Worker should be available on the workers.dev subdomain.
@@ -144,14 +163,14 @@ export interface SubdomainDeleteParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 export interface SubdomainGetParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 export declare namespace Subdomain {

--- a/src/resources/workers/scripts/tail.ts
+++ b/src/resources/workers/scripts/tail.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../../resource';
+import { isRequestOptions } from '../../../core';
 import * as Core from '../../../core';
 
 export class Tail extends APIResource {
@@ -23,7 +24,7 @@ export class Tail extends APIResource {
     params: TailCreateParams,
     options?: Core.RequestOptions,
   ): Core.APIPromise<TailCreateResponse> {
-    const { account_id, body } = params;
+    const { account_id = this._client.accountId, body } = params;
     return (
       this._client.post(`/accounts/${account_id}/workers/scripts/${scriptName}/tails`, {
         body: body,
@@ -47,10 +48,20 @@ export class Tail extends APIResource {
   delete(
     scriptName: string,
     id: string,
-    params: TailDeleteParams,
+    params?: TailDeleteParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<TailDeleteResponse>;
+  delete(scriptName: string, id: string, options?: Core.RequestOptions): Core.APIPromise<TailDeleteResponse>;
+  delete(
+    scriptName: string,
+    id: string,
+    params: TailDeleteParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<TailDeleteResponse> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.delete(scriptName, id, {}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return this._client.delete(`/accounts/${account_id}/workers/scripts/${scriptName}/tails/${id}`, options);
   }
 
@@ -67,10 +78,19 @@ export class Tail extends APIResource {
    */
   get(
     scriptName: string,
-    params: TailGetParams,
+    params?: TailGetParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<TailGetResponse>;
+  get(scriptName: string, options?: Core.RequestOptions): Core.APIPromise<TailGetResponse>;
+  get(
+    scriptName: string,
+    params: TailGetParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<TailGetResponse> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.get(scriptName, {}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return (
       this._client.get(
         `/accounts/${account_id}/workers/scripts/${scriptName}/tails`,
@@ -191,7 +211,7 @@ export interface TailCreateParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param
@@ -203,14 +223,14 @@ export interface TailDeleteParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 export interface TailGetParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 export declare namespace Tail {

--- a/src/resources/workers/scripts/versions.ts
+++ b/src/resources/workers/scripts/versions.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../../resource';
+import { isRequestOptions } from '../../../core';
 import * as Core from '../../../core';
 import { V4PagePagination, type V4PagePaginationParams } from '../../../pagination';
 
@@ -27,7 +28,7 @@ export class Versions extends APIResource {
     params: VersionCreateParams,
     options?: Core.RequestOptions,
   ): Core.APIPromise<VersionCreateResponse> {
-    const { account_id, bindings_inherit, ...body } = params;
+    const { account_id = this._client.accountId, bindings_inherit, ...body } = params;
     return (
       this._client.post(
         `/accounts/${account_id}/workers/scripts/${scriptName}/versions`,
@@ -57,10 +58,22 @@ export class Versions extends APIResource {
    */
   list(
     scriptName: string,
-    params: VersionListParams,
+    params?: VersionListParams,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<VersionListResponsesV4PagePagination, VersionListResponse>;
+  list(
+    scriptName: string,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<VersionListResponsesV4PagePagination, VersionListResponse>;
+  list(
+    scriptName: string,
+    params: VersionListParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.PagePromise<VersionListResponsesV4PagePagination, VersionListResponse> {
-    const { account_id, ...query } = params;
+    if (isRequestOptions(params)) {
+      return this.list(scriptName, {}, params);
+    }
+    const { account_id = this._client.accountId, ...query } = params;
     return this._client.getAPIList(
       `/accounts/${account_id}/workers/scripts/${scriptName}/versions`,
       VersionListResponsesV4PagePagination,
@@ -83,10 +96,24 @@ export class Versions extends APIResource {
   get(
     scriptName: string,
     versionId: string,
-    params: VersionGetParams,
+    params?: VersionGetParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<VersionGetResponse>;
+  get(
+    scriptName: string,
+    versionId: string,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<VersionGetResponse>;
+  get(
+    scriptName: string,
+    versionId: string,
+    params: VersionGetParams | Core.RequestOptions = {},
     options?: Core.RequestOptions,
   ): Core.APIPromise<VersionGetResponse> {
-    const { account_id } = params;
+    if (isRequestOptions(params)) {
+      return this.get(scriptName, versionId, {}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return (
       this._client.get(
         `/accounts/${account_id}/workers/scripts/${scriptName}/versions/${versionId}`,
@@ -2050,7 +2077,7 @@ export interface VersionCreateParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param: JSON-encoded metadata about the uploaded parts and Worker
@@ -2946,7 +2973,7 @@ export interface VersionListParams extends V4PagePaginationParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Query param: Only return versions that can be used in a deployment. Ignores
@@ -2959,7 +2986,7 @@ export interface VersionGetParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 Versions.VersionListResponsesV4PagePagination = VersionListResponsesV4PagePagination;

--- a/src/resources/workers/subdomains.ts
+++ b/src/resources/workers/subdomains.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';
+import { isRequestOptions } from '../../core';
 import * as Core from '../../core';
 
 export class Subdomains extends APIResource {
@@ -19,7 +20,7 @@ export class Subdomains extends APIResource {
     params: SubdomainUpdateParams,
     options?: Core.RequestOptions,
   ): Core.APIPromise<SubdomainUpdateResponse> {
-    const { account_id, ...body } = params;
+    const { account_id = this._client.accountId, ...body } = params;
     return (
       this._client.put(`/accounts/${account_id}/workers/subdomain`, { body, ...options }) as Core.APIPromise<{
         result: SubdomainUpdateResponse;
@@ -37,8 +38,16 @@ export class Subdomains extends APIResource {
    * });
    * ```
    */
-  delete(params: SubdomainDeleteParams, options?: Core.RequestOptions): Core.APIPromise<void> {
-    const { account_id } = params;
+  delete(params?: SubdomainDeleteParams, options?: Core.RequestOptions): Core.APIPromise<void>;
+  delete(options?: Core.RequestOptions): Core.APIPromise<void>;
+  delete(
+    params: SubdomainDeleteParams | Core.RequestOptions = {},
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<void> {
+    if (isRequestOptions(params)) {
+      return this.delete({}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return this._client.delete(`/accounts/${account_id}/workers/subdomain`, {
       ...options,
       headers: { Accept: '*/*', ...options?.headers },
@@ -55,8 +64,16 @@ export class Subdomains extends APIResource {
    * });
    * ```
    */
-  get(params: SubdomainGetParams, options?: Core.RequestOptions): Core.APIPromise<SubdomainGetResponse> {
-    const { account_id } = params;
+  get(params?: SubdomainGetParams, options?: Core.RequestOptions): Core.APIPromise<SubdomainGetResponse>;
+  get(options?: Core.RequestOptions): Core.APIPromise<SubdomainGetResponse>;
+  get(
+    params: SubdomainGetParams | Core.RequestOptions = {},
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<SubdomainGetResponse> {
+    if (isRequestOptions(params)) {
+      return this.get({}, params);
+    }
+    const { account_id = this._client.accountId } = params;
     return (
       this._client.get(`/accounts/${account_id}/workers/subdomain`, options) as Core.APIPromise<{
         result: SubdomainGetResponse;
@@ -77,7 +94,7 @@ export interface SubdomainUpdateParams {
   /**
    * Path param: Identifier.
    */
-  account_id: string;
+  account_id?: string;
 
   /**
    * Body param
@@ -89,14 +106,14 @@ export interface SubdomainDeleteParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 export interface SubdomainGetParams {
   /**
    * Identifier.
    */
-  account_id: string;
+  account_id?: string;
 }
 
 export declare namespace Subdomains {

--- a/tests/api-resources/radar/agent-readiness.test.ts
+++ b/tests/api-resources/radar/agent-readiness.test.ts
@@ -1,0 +1,46 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+import Cloudflare from 'cloudflare';
+import { Response } from 'node-fetch';
+
+const client = new Cloudflare({
+  apiKey: '144c9defac04969c7bfad8efaa8ea194',
+  apiEmail: 'user@example.com',
+  baseURL: process.env['TEST_API_BASE_URL'] ?? 'http://127.0.0.1:4010',
+});
+
+describe('resource agentReadiness', () => {
+  test('summary', async () => {
+    const responsePromise = client.radar.agentReadiness.summary('CHECK');
+    const rawResponse = await responsePromise.asResponse();
+    expect(rawResponse).toBeInstanceOf(Response);
+    const response = await responsePromise;
+    expect(response).not.toBeInstanceOf(Response);
+    const dataAndResponse = await responsePromise.withResponse();
+    expect(dataAndResponse.data).toBe(response);
+    expect(dataAndResponse.response).toBe(rawResponse);
+  });
+
+  test('summary: request options instead of params are passed correctly', async () => {
+    // ensure the request options are being passed correctly by passing an invalid HTTP method in order to cause an error
+    await expect(
+      client.radar.agentReadiness.summary('CHECK', { path: '/_stainless_unknown_path' }),
+    ).rejects.toThrow(Cloudflare.NotFoundError);
+  });
+
+  test('summary: request options and params are passed correctly', async () => {
+    // ensure the request options are being passed correctly by passing an invalid HTTP method in order to cause an error
+    await expect(
+      client.radar.agentReadiness.summary(
+        'CHECK',
+        {
+          date: '2024-09-19',
+          domainCategory: ['string'],
+          format: 'JSON',
+          name: ['main_series'],
+        },
+        { path: '/_stainless_unknown_path' },
+      ),
+    ).rejects.toThrow(Cloudflare.NotFoundError);
+  });
+});

--- a/tests/api-resources/radar/ai/markdown-for-agents.test.ts
+++ b/tests/api-resources/radar/ai/markdown-for-agents.test.ts
@@ -1,0 +1,81 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+import Cloudflare from 'cloudflare';
+import { Response } from 'node-fetch';
+
+const client = new Cloudflare({
+  apiKey: '144c9defac04969c7bfad8efaa8ea194',
+  apiEmail: 'user@example.com',
+  baseURL: process.env['TEST_API_BASE_URL'] ?? 'http://127.0.0.1:4010',
+});
+
+describe('resource markdownForAgents', () => {
+  test('summary', async () => {
+    const responsePromise = client.radar.ai.markdownForAgents.summary();
+    const rawResponse = await responsePromise.asResponse();
+    expect(rawResponse).toBeInstanceOf(Response);
+    const response = await responsePromise;
+    expect(response).not.toBeInstanceOf(Response);
+    const dataAndResponse = await responsePromise.withResponse();
+    expect(dataAndResponse.data).toBe(response);
+    expect(dataAndResponse.response).toBe(rawResponse);
+  });
+
+  test('summary: request options instead of params are passed correctly', async () => {
+    // ensure the request options are being passed correctly by passing an invalid HTTP method in order to cause an error
+    await expect(
+      client.radar.ai.markdownForAgents.summary({ path: '/_stainless_unknown_path' }),
+    ).rejects.toThrow(Cloudflare.NotFoundError);
+  });
+
+  test('summary: request options and params are passed correctly', async () => {
+    // ensure the request options are being passed correctly by passing an invalid HTTP method in order to cause an error
+    await expect(
+      client.radar.ai.markdownForAgents.summary(
+        {
+          dateEnd: ['2019-12-27T18:11:19.117Z'],
+          dateRange: ['7d'],
+          dateStart: ['2019-12-27T18:11:19.117Z'],
+          format: 'JSON',
+          name: ['main_series'],
+        },
+        { path: '/_stainless_unknown_path' },
+      ),
+    ).rejects.toThrow(Cloudflare.NotFoundError);
+  });
+
+  test('timeseries', async () => {
+    const responsePromise = client.radar.ai.markdownForAgents.timeseries();
+    const rawResponse = await responsePromise.asResponse();
+    expect(rawResponse).toBeInstanceOf(Response);
+    const response = await responsePromise;
+    expect(response).not.toBeInstanceOf(Response);
+    const dataAndResponse = await responsePromise.withResponse();
+    expect(dataAndResponse.data).toBe(response);
+    expect(dataAndResponse.response).toBe(rawResponse);
+  });
+
+  test('timeseries: request options instead of params are passed correctly', async () => {
+    // ensure the request options are being passed correctly by passing an invalid HTTP method in order to cause an error
+    await expect(
+      client.radar.ai.markdownForAgents.timeseries({ path: '/_stainless_unknown_path' }),
+    ).rejects.toThrow(Cloudflare.NotFoundError);
+  });
+
+  test('timeseries: request options and params are passed correctly', async () => {
+    // ensure the request options are being passed correctly by passing an invalid HTTP method in order to cause an error
+    await expect(
+      client.radar.ai.markdownForAgents.timeseries(
+        {
+          aggInterval: '1h',
+          dateEnd: ['2019-12-27T18:11:19.117Z'],
+          dateRange: ['7d'],
+          dateStart: ['2019-12-27T18:11:19.117Z'],
+          format: 'JSON',
+          name: ['main_series'],
+        },
+        { path: '/_stainless_unknown_path' },
+      ),
+    ).rejects.toThrow(Cloudflare.NotFoundError);
+  });
+});


### PR DESCRIPTION
## Codegen Sync: staging-next -> next

Synced 3 of 3 resources from `staging-next` as of 2026-04-15. These are the
resources excluded from the previous sync (#2733) due to tsc type errors and
eslint formatting violations. The fixes from `next` (#2730) were merged back
into `staging-next` and a fresh codegen run resolved all issues.

### Integrated Resources

| Resource | Type | Summary |
|----------|------|---------|
| ai | chore | update generated types and methods |
| radar | feat | add agent-readiness, ai/markdown-for-agents |
| workers | chore | update generated types and methods |

### Excluded Resources

None.

### Shared Changes

- Updated `.stats.yml` codegen metadata