### PR TITLE
fix(rulesets): revert erroneous removal of rulesets resource methods and types

### DIFF
--- a/api.md
+++ b/api.md
@@ -2901,10 +2901,42 @@ Types:
 - <code><a href="./src/resources/rulesets/rulesets.ts">Kind</a></code>
 - <code><a href="./src/resources/rulesets/rulesets.ts">Phase</a></code>
 - <code><a href="./src/resources/rulesets/rulesets.ts">Ruleset</a></code>
+- <code><a href="./src/resources/rulesets/rulesets.ts">RulesetCreateResponse</a></code>
+- <code><a href="./src/resources/rulesets/rulesets.ts">RulesetUpdateResponse</a></code>
+- <code><a href="./src/resources/rulesets/rulesets.ts">RulesetListResponse</a></code>
+- <code><a href="./src/resources/rulesets/rulesets.ts">RulesetGetResponse</a></code>
+
+Methods:
+
+- <code title="post /{accounts_or_zones}/{account_or_zone_id}/rulesets">client.rulesets.<a href="./src/resources/rulesets/rulesets.ts">create</a>({ ...params }) -> RulesetCreateResponse</code>
+- <code title="put /{accounts_or_zones}/{account_or_zone_id}/rulesets/{ruleset_id}">client.rulesets.<a href="./src/resources/rulesets/rulesets.ts">update</a>(rulesetId, { ...params }) -> RulesetUpdateResponse</code>
+- <code title="get /{accounts_or_zones}/{account_or_zone_id}/rulesets">client.rulesets.<a href="./src/resources/rulesets/rulesets.ts">list</a>({ ...params }) -> RulesetListResponsesCursorPagination</code>
+- <code title="delete /{accounts_or_zones}/{account_or_zone_id}/rulesets/{ruleset_id}">client.rulesets.<a href="./src/resources/rulesets/rulesets.ts">delete</a>(rulesetId, { ...params }) -> void</code>
+- <code title="get /{accounts_or_zones}/{account_or_zone_id}/rulesets/{ruleset_id}">client.rulesets.<a href="./src/resources/rulesets/rulesets.ts">get</a>(rulesetId, { ...params }) -> RulesetGetResponse</code>
 
 ## Phases
 
+Types:
+
+- <code><a href="./src/resources/rulesets/phases/phases.ts">PhaseUpdateResponse</a></code>
+- <code><a href="./src/resources/rulesets/phases/phases.ts">PhaseGetResponse</a></code>
+
+Methods:
+
+- <code title="put /{accounts_or_zones}/{account_or_zone_id}/rulesets/phases/{ruleset_phase}/entrypoint">client.rulesets.phases.<a href="./src/resources/rulesets/phases/phases.ts">update</a>(rulesetPhase, { ...params }) -> PhaseUpdateResponse</code>
+- <code title="get /{accounts_or_zones}/{account_or_zone_id}/rulesets/phases/{ruleset_phase}/entrypoint">client.rulesets.phases.<a href="./src/resources/rulesets/phases/phases.ts">get</a>(rulesetPhase, { ...params }) -> PhaseGetResponse</code>
+
 ### Versions
+
+Types:
+
+- <code><a href="./src/resources/rulesets/phases/versions.ts">VersionListResponse</a></code>
+- <code><a href="./src/resources/rulesets/phases/versions.ts">VersionGetResponse</a></code>
+
+Methods:
+
+- <code title="get /{accounts_or_zones}/{account_or_zone_id}/rulesets/phases/{ruleset_phase}/entrypoint/versions">client.rulesets.phases.versions.<a href="./src/resources/rulesets/phases/versions.ts">list</a>(rulesetPhase, { ...params }) -> VersionListResponsesSinglePage</code>
+- <code title="get /{accounts_or_zones}/{account_or_zone_id}/rulesets/phases/{ruleset_phase}/entrypoint/versions/{ruleset_version}">client.rulesets.phases.versions.<a href="./src/resources/rulesets/phases/versions.ts">get</a>(rulesetPhase, rulesetVersion, { ...params }) -> VersionGetResponse</code>
 
 ## Rules
 
@@ -2928,8 +2960,28 @@ Types:
 - <code><a href="./src/resources/rulesets/rules.ts">SetCacheSettingsRule</a></code>
 - <code><a href="./src/resources/rulesets/rules.ts">SetConfigRule</a></code>
 - <code><a href="./src/resources/rulesets/rules.ts">SkipRule</a></code>
+- <code><a href="./src/resources/rulesets/rules.ts">RuleCreateResponse</a></code>
+- <code><a href="./src/resources/rulesets/rules.ts">RuleDeleteResponse</a></code>
+- <code><a href="./src/resources/rulesets/rules.ts">RuleEditResponse</a></code>
+
+Methods:
+
+- <code title="post /{accounts_or_zones}/{account_or_zone_id}/rulesets/{ruleset_id}/rules">client.rulesets.rules.<a href="./src/resources/rulesets/rules.ts">create</a>(rulesetId, { ...params }) -> RuleCreateResponse</code>
+- <code title="delete /{accounts_or_zones}/{account_or_zone_id}/rulesets/{ruleset_id}/rules/{rule_id}">client.rulesets.rules.<a href="./src/resources/rulesets/rules.ts">delete</a>(rulesetId, ruleId, { ...params }) -> RuleDeleteResponse</code>
+- <code title="patch /{accounts_or_zones}/{account_or_zone_id}/rulesets/{ruleset_id}/rules/{rule_id}">client.rulesets.rules.<a href="./src/resources/rulesets/rules.ts">edit</a>(rulesetId, ruleId, { ...params }) -> RuleEditResponse</code>
 
 ## Versions
+
+Types:
+
+- <code><a href="./src/resources/rulesets/versions.ts">VersionListResponse</a></code>
+- <code><a href="./src/resources/rulesets/versions.ts">VersionGetResponse</a></code>
+
+Methods:
+
+- <code title="get /{accounts_or_zones}/{account_or_zone_id}/rulesets/{ruleset_id}/versions">client.rulesets.versions.<a href="./src/resources/rulesets/versions.ts">list</a>(rulesetId, { ...params }) -> VersionListResponsesSinglePage</code>
+- <code title="delete /{accounts_or_zones}/{account_or_zone_id}/rulesets/{ruleset_id}/versions/{ruleset_version}">client.rulesets.versions.<a href="./src/resources/rulesets/versions.ts">delete</a>(rulesetId, rulesetVersion, { ...params }) -> void</code>
+- <code title="get /{accounts_or_zones}/{account_or_zone_id}/rulesets/{ruleset_id}/versions/{ruleset_version}">client.rulesets.versions.<a href="./src/resources/rulesets/versions.ts">get</a>(rulesetId, rulesetVersion, { ...params }) -> VersionGetResponse</code>
 
 # URLNormalization
 

--- a/src/resources/rulesets/index.ts
+++ b/src/resources/rulesets/index.ts
@@ -1,6 +1,12 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-export { Phases } from './phases/index';
+export {
+  Phases,
+  type PhaseUpdateResponse,
+  type PhaseGetResponse,
+  type PhaseUpdateParams,
+  type PhaseGetParams,
+} from './phases/index';
 export {
   Rules,
   type BlockRule,
@@ -21,6 +27,20 @@ export {
   type SetCacheSettingsRule,
   type SetConfigRule,
   type SkipRule,
+  type RuleCreateResponse,
+  type RuleDeleteResponse,
+  type RuleEditResponse,
+  type RuleCreateParams,
+  type RuleDeleteParams,
+  type RuleEditParams,
 } from './rules';
 export { Rulesets } from './rulesets';
-export { Versions } from './versions';
+export {
+  VersionListResponsesSinglePage,
+  Versions,
+  type VersionListResponse,
+  type VersionGetResponse,
+  type VersionListParams,
+  type VersionDeleteParams,
+  type VersionGetParams,
+} from './versions';

--- a/src/resources/rulesets/phases/index.ts
+++ b/src/resources/rulesets/phases/index.ts
@@ -1,4 +1,17 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-export { Phases } from './phases';
-export { Versions } from './versions';
+export {
+  Phases,
+  type PhaseUpdateResponse,
+  type PhaseGetResponse,
+  type PhaseUpdateParams,
+  type PhaseGetParams,
+} from './phases';
+export {
+  VersionListResponsesSinglePage,
+  Versions,
+  type VersionListResponse,
+  type VersionGetResponse,
+  type VersionListParams,
+  type VersionGetParams,
+} from './versions';

--- a/src/resources/rulesets/phases/phases.ts
+++ b/src/resources/rulesets/phases/phases.ts
@@ -1,15 +1,1108 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../../resource';
+import { isRequestOptions } from '../../../core';
+import * as Core from '../../../core';
+import * as RulesAPI from '../rules';
+import * as RulesetsAPI from '../rulesets';
 import * as VersionsAPI from './versions';
-import { Versions } from './versions';
+import {
+  VersionGetParams,
+  VersionGetResponse,
+  VersionListParams,
+  VersionListResponse,
+  VersionListResponsesSinglePage,
+  Versions,
+} from './versions';
+import { CloudflareError } from '../../../error';
 
 export class Phases extends APIResource {
   versions: VersionsAPI.Versions = new VersionsAPI.Versions(this._client);
+
+  /**
+   * Updates an account or zone entry point ruleset, creating a new version.
+   *
+   * @example
+   * ```ts
+   * const phase = await client.rulesets.phases.update(
+   *   'http_request_firewall_custom',
+   *   { account_id: 'account_id' },
+   * );
+   * ```
+   */
+  update(
+    rulesetPhase: RulesetsAPI.PhaseParam,
+    params: PhaseUpdateParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<PhaseUpdateResponse> {
+    const { account_id, zone_id, ...body } = params;
+    if (!account_id && !zone_id) {
+      throw new CloudflareError('You must provide either account_id or zone_id.');
+    }
+    if (account_id && zone_id) {
+      throw new CloudflareError('You cannot provide both account_id and zone_id.');
+    }
+    const { accountOrZone, accountOrZoneId } =
+      account_id ?
+        {
+          accountOrZone: 'accounts',
+          accountOrZoneId: account_id,
+        }
+      : {
+          accountOrZone: 'zones',
+          accountOrZoneId: zone_id,
+        };
+    return (
+      this._client.put(`/${accountOrZone}/${accountOrZoneId}/rulesets/phases/${rulesetPhase}/entrypoint`, {
+        body,
+        ...options,
+      }) as Core.APIPromise<{ result: PhaseUpdateResponse }>
+    )._thenUnwrap((obj) => obj.result);
+  }
+
+  /**
+   * Fetches the latest version of the account or zone entry point ruleset for a
+   * given phase.
+   *
+   * @example
+   * ```ts
+   * const phase = await client.rulesets.phases.get(
+   *   'http_request_firewall_custom',
+   *   { account_id: 'account_id' },
+   * );
+   * ```
+   */
+  get(
+    rulesetPhase: RulesetsAPI.PhaseParam,
+    params?: PhaseGetParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<PhaseGetResponse>;
+  get(rulesetPhase: RulesetsAPI.PhaseParam, options?: Core.RequestOptions): Core.APIPromise<PhaseGetResponse>;
+  get(
+    rulesetPhase: RulesetsAPI.PhaseParam,
+    params: PhaseGetParams | Core.RequestOptions = {},
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<PhaseGetResponse> {
+    if (isRequestOptions(params)) {
+      return this.get(rulesetPhase, {}, params);
+    }
+    const { account_id, zone_id } = params;
+    if (!account_id && !zone_id) {
+      throw new CloudflareError('You must provide either account_id or zone_id.');
+    }
+    if (account_id && zone_id) {
+      throw new CloudflareError('You cannot provide both account_id and zone_id.');
+    }
+    const { accountOrZone, accountOrZoneId } =
+      account_id ?
+        {
+          accountOrZone: 'accounts',
+          accountOrZoneId: account_id,
+        }
+      : {
+          accountOrZone: 'zones',
+          accountOrZoneId: zone_id,
+        };
+    return (
+      this._client.get(
+        `/${accountOrZone}/${accountOrZoneId}/rulesets/phases/${rulesetPhase}/entrypoint`,
+        options,
+      ) as Core.APIPromise<{ result: PhaseGetResponse }>
+    )._thenUnwrap((obj) => obj.result);
+  }
+}
+
+/**
+ * A ruleset object.
+ */
+export interface PhaseUpdateResponse {
+  /**
+   * The unique ID of the ruleset.
+   */
+  id: string;
+
+  /**
+   * The kind of the ruleset.
+   */
+  kind: RulesetsAPI.Kind;
+
+  /**
+   * The timestamp of when the ruleset was last modified.
+   */
+  last_updated: string;
+
+  /**
+   * The human-readable name of the ruleset.
+   */
+  name: string;
+
+  /**
+   * The phase of the ruleset.
+   */
+  phase: RulesetsAPI.Phase;
+
+  /**
+   * The list of rules in the ruleset.
+   */
+  rules: Array<
+    | RulesAPI.BlockRule
+    | PhaseUpdateResponse.RulesetsChallengeRule
+    | RulesAPI.CompressResponseRule
+    | RulesAPI.DDoSDynamicRule
+    | RulesAPI.ExecuteRule
+    | RulesAPI.ForceConnectionCloseRule
+    | PhaseUpdateResponse.RulesetsJSChallengeRule
+    | RulesAPI.LogRule
+    | RulesAPI.LogCustomFieldRule
+    | RulesAPI.ManagedChallengeRule
+    | RulesAPI.RedirectRule
+    | RulesAPI.RewriteRule
+    | RulesAPI.RouteRule
+    | RulesAPI.ScoreRule
+    | RulesAPI.ServeErrorRule
+    | RulesAPI.SetCacheSettingsRule
+    | RulesAPI.SetConfigRule
+    | RulesAPI.SkipRule
+  >;
+
+  /**
+   * The version of the ruleset.
+   */
+  version: string;
+
+  /**
+   * An informative description of the ruleset.
+   */
+  description?: string;
+}
+
+export namespace PhaseUpdateResponse {
+  export interface RulesetsChallengeRule {
+    /**
+     * The timestamp of when the rule was last modified.
+     */
+    last_updated: string;
+
+    /**
+     * The version of the rule.
+     */
+    version: string;
+
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * The categories of the rule.
+     */
+    categories?: Array<string>;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.Logging;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface RulesetsJSChallengeRule {
+    /**
+     * The timestamp of when the rule was last modified.
+     */
+    last_updated: string;
+
+    /**
+     * The version of the rule.
+     */
+    version: string;
+
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'js_challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * The categories of the rule.
+     */
+    categories?: Array<string>;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsJSChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.Logging;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsJSChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsJSChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+}
+
+/**
+ * A ruleset object.
+ */
+export interface PhaseGetResponse {
+  /**
+   * The unique ID of the ruleset.
+   */
+  id: string;
+
+  /**
+   * The kind of the ruleset.
+   */
+  kind: RulesetsAPI.Kind;
+
+  /**
+   * The timestamp of when the ruleset was last modified.
+   */
+  last_updated: string;
+
+  /**
+   * The human-readable name of the ruleset.
+   */
+  name: string;
+
+  /**
+   * The phase of the ruleset.
+   */
+  phase: RulesetsAPI.Phase;
+
+  /**
+   * The list of rules in the ruleset.
+   */
+  rules: Array<
+    | RulesAPI.BlockRule
+    | PhaseGetResponse.RulesetsChallengeRule
+    | RulesAPI.CompressResponseRule
+    | RulesAPI.DDoSDynamicRule
+    | RulesAPI.ExecuteRule
+    | RulesAPI.ForceConnectionCloseRule
+    | PhaseGetResponse.RulesetsJSChallengeRule
+    | RulesAPI.LogRule
+    | RulesAPI.LogCustomFieldRule
+    | RulesAPI.ManagedChallengeRule
+    | RulesAPI.RedirectRule
+    | RulesAPI.RewriteRule
+    | RulesAPI.RouteRule
+    | RulesAPI.ScoreRule
+    | RulesAPI.ServeErrorRule
+    | RulesAPI.SetCacheSettingsRule
+    | RulesAPI.SetConfigRule
+    | RulesAPI.SkipRule
+  >;
+
+  /**
+   * The version of the ruleset.
+   */
+  version: string;
+
+  /**
+   * An informative description of the ruleset.
+   */
+  description?: string;
+}
+
+export namespace PhaseGetResponse {
+  export interface RulesetsChallengeRule {
+    /**
+     * The timestamp of when the rule was last modified.
+     */
+    last_updated: string;
+
+    /**
+     * The version of the rule.
+     */
+    version: string;
+
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * The categories of the rule.
+     */
+    categories?: Array<string>;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.Logging;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface RulesetsJSChallengeRule {
+    /**
+     * The timestamp of when the rule was last modified.
+     */
+    last_updated: string;
+
+    /**
+     * The version of the rule.
+     */
+    version: string;
+
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'js_challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * The categories of the rule.
+     */
+    categories?: Array<string>;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsJSChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.Logging;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsJSChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsJSChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+}
+
+export interface PhaseUpdateParams {
+  /**
+   * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+   * Zone ID.
+   */
+  account_id?: string;
+
+  /**
+   * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+   * Account ID.
+   */
+  zone_id?: string;
+
+  /**
+   * Body param: An informative description of the ruleset.
+   */
+  description?: string;
+
+  /**
+   * Body param: The human-readable name of the ruleset.
+   */
+  name?: string;
+
+  /**
+   * Body param: The list of rules in the ruleset.
+   */
+  rules?: Array<
+    | RulesAPI.BlockRuleParam
+    | PhaseUpdateParams.RulesetsChallengeRule
+    | RulesAPI.CompressResponseRuleParam
+    | RulesAPI.DDoSDynamicRuleParam
+    | RulesAPI.ExecuteRuleParam
+    | RulesAPI.ForceConnectionCloseRuleParam
+    | PhaseUpdateParams.RulesetsJSChallengeRule
+    | RulesAPI.LogRuleParam
+    | RulesAPI.LogCustomFieldRuleParam
+    | RulesAPI.ManagedChallengeRuleParam
+    | RulesAPI.RedirectRuleParam
+    | RulesAPI.RewriteRuleParam
+    | RulesAPI.RouteRuleParam
+    | RulesAPI.ScoreRuleParam
+    | RulesAPI.ServeErrorRuleParam
+    | RulesAPI.SetCacheSettingsRuleParam
+    | RulesAPI.SetConfigRuleParam
+    | RulesAPI.SkipRuleParam
+  >;
+}
+
+export namespace PhaseUpdateParams {
+  export interface RulesetsChallengeRule {
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.LoggingParam;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface RulesetsJSChallengeRule {
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'js_challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsJSChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.LoggingParam;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsJSChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsJSChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+}
+
+export interface PhaseGetParams {
+  /**
+   * The Account ID to use for this endpoint. Mutually exclusive with the Zone ID.
+   */
+  account_id?: string;
+
+  /**
+   * The Zone ID to use for this endpoint. Mutually exclusive with the Account ID.
+   */
+  zone_id?: string;
 }
 
 Phases.Versions = Versions;
+Phases.VersionListResponsesSinglePage = VersionListResponsesSinglePage;
 
 export declare namespace Phases {
-  export { Versions as Versions };
+  export {
+    type PhaseUpdateResponse as PhaseUpdateResponse,
+    type PhaseGetResponse as PhaseGetResponse,
+    type PhaseUpdateParams as PhaseUpdateParams,
+    type PhaseGetParams as PhaseGetParams,
+  };
+
+  export {
+    Versions as Versions,
+    type VersionListResponse as VersionListResponse,
+    type VersionGetResponse as VersionGetResponse,
+    VersionListResponsesSinglePage as VersionListResponsesSinglePage,
+    type VersionListParams as VersionListParams,
+    type VersionGetParams as VersionGetParams,
+  };
 }

--- a/src/resources/rulesets/phases/versions.ts
+++ b/src/resources/rulesets/phases/versions.ts
@@ -1,5 +1,537 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../../resource';
+import { isRequestOptions } from '../../../core';
+import * as Core from '../../../core';
+import * as RulesAPI from '../rules';
+import * as RulesetsAPI from '../rulesets';
+import { CloudflareError } from '../../../error';
+import { SinglePage } from '../../../pagination';
 
-export class Versions extends APIResource {}
+export class Versions extends APIResource {
+  /**
+   * Fetches the versions of an account or zone entry point ruleset.
+   *
+   * @example
+   * ```ts
+   * // Automatically fetches more pages as needed.
+   * for await (const versionListResponse of client.rulesets.phases.versions.list(
+   *   'http_request_firewall_custom',
+   *   { account_id: 'account_id' },
+   * )) {
+   *   // ...
+   * }
+   * ```
+   */
+  list(
+    rulesetPhase: RulesetsAPI.PhaseParam,
+    params?: VersionListParams,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<VersionListResponsesSinglePage, VersionListResponse>;
+  list(
+    rulesetPhase: RulesetsAPI.PhaseParam,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<VersionListResponsesSinglePage, VersionListResponse>;
+  list(
+    rulesetPhase: RulesetsAPI.PhaseParam,
+    params: VersionListParams | Core.RequestOptions = {},
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<VersionListResponsesSinglePage, VersionListResponse> {
+    if (isRequestOptions(params)) {
+      return this.list(rulesetPhase, {}, params);
+    }
+    const { account_id, zone_id } = params;
+    if (!account_id && !zone_id) {
+      throw new CloudflareError('You must provide either account_id or zone_id.');
+    }
+    if (account_id && zone_id) {
+      throw new CloudflareError('You cannot provide both account_id and zone_id.');
+    }
+    const { accountOrZone, accountOrZoneId } =
+      account_id ?
+        {
+          accountOrZone: 'accounts',
+          accountOrZoneId: account_id,
+        }
+      : {
+          accountOrZone: 'zones',
+          accountOrZoneId: zone_id,
+        };
+    return this._client.getAPIList(
+      `/${accountOrZone}/${accountOrZoneId}/rulesets/phases/${rulesetPhase}/entrypoint/versions`,
+      VersionListResponsesSinglePage,
+      options,
+    );
+  }
+
+  /**
+   * Fetches a specific version of an account or zone entry point ruleset.
+   *
+   * @example
+   * ```ts
+   * const version = await client.rulesets.phases.versions.get(
+   *   'http_request_firewall_custom',
+   *   '1',
+   *   { account_id: 'account_id' },
+   * );
+   * ```
+   */
+  get(
+    rulesetPhase: RulesetsAPI.PhaseParam,
+    rulesetVersion: string,
+    params?: VersionGetParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<VersionGetResponse>;
+  get(
+    rulesetPhase: RulesetsAPI.PhaseParam,
+    rulesetVersion: string,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<VersionGetResponse>;
+  get(
+    rulesetPhase: RulesetsAPI.PhaseParam,
+    rulesetVersion: string,
+    params: VersionGetParams | Core.RequestOptions = {},
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<VersionGetResponse> {
+    if (isRequestOptions(params)) {
+      return this.get(rulesetPhase, rulesetVersion, {}, params);
+    }
+    const { account_id, zone_id } = params;
+    if (!account_id && !zone_id) {
+      throw new CloudflareError('You must provide either account_id or zone_id.');
+    }
+    if (account_id && zone_id) {
+      throw new CloudflareError('You cannot provide both account_id and zone_id.');
+    }
+    const { accountOrZone, accountOrZoneId } =
+      account_id ?
+        {
+          accountOrZone: 'accounts',
+          accountOrZoneId: account_id,
+        }
+      : {
+          accountOrZone: 'zones',
+          accountOrZoneId: zone_id,
+        };
+    return (
+      this._client.get(
+        `/${accountOrZone}/${accountOrZoneId}/rulesets/phases/${rulesetPhase}/entrypoint/versions/${rulesetVersion}`,
+        options,
+      ) as Core.APIPromise<{ result: VersionGetResponse }>
+    )._thenUnwrap((obj) => obj.result);
+  }
+}
+
+export class VersionListResponsesSinglePage extends SinglePage<VersionListResponse> {}
+
+/**
+ * A ruleset object.
+ */
+export interface VersionListResponse {
+  /**
+   * The unique ID of the ruleset.
+   */
+  id: string;
+
+  /**
+   * The kind of the ruleset.
+   */
+  kind: RulesetsAPI.Kind;
+
+  /**
+   * The timestamp of when the ruleset was last modified.
+   */
+  last_updated: string;
+
+  /**
+   * The human-readable name of the ruleset.
+   */
+  name: string;
+
+  /**
+   * The phase of the ruleset.
+   */
+  phase: RulesetsAPI.Phase;
+
+  /**
+   * The version of the ruleset.
+   */
+  version: string;
+
+  /**
+   * An informative description of the ruleset.
+   */
+  description?: string;
+}
+
+/**
+ * A ruleset object.
+ */
+export interface VersionGetResponse {
+  /**
+   * The unique ID of the ruleset.
+   */
+  id: string;
+
+  /**
+   * The kind of the ruleset.
+   */
+  kind: RulesetsAPI.Kind;
+
+  /**
+   * The timestamp of when the ruleset was last modified.
+   */
+  last_updated: string;
+
+  /**
+   * The human-readable name of the ruleset.
+   */
+  name: string;
+
+  /**
+   * The phase of the ruleset.
+   */
+  phase: RulesetsAPI.Phase;
+
+  /**
+   * The list of rules in the ruleset.
+   */
+  rules: Array<
+    | RulesAPI.BlockRule
+    | VersionGetResponse.RulesetsChallengeRule
+    | RulesAPI.CompressResponseRule
+    | RulesAPI.DDoSDynamicRule
+    | RulesAPI.ExecuteRule
+    | RulesAPI.ForceConnectionCloseRule
+    | VersionGetResponse.RulesetsJSChallengeRule
+    | RulesAPI.LogRule
+    | RulesAPI.LogCustomFieldRule
+    | RulesAPI.ManagedChallengeRule
+    | RulesAPI.RedirectRule
+    | RulesAPI.RewriteRule
+    | RulesAPI.RouteRule
+    | RulesAPI.ScoreRule
+    | RulesAPI.ServeErrorRule
+    | RulesAPI.SetCacheSettingsRule
+    | RulesAPI.SetConfigRule
+    | RulesAPI.SkipRule
+  >;
+
+  /**
+   * The version of the ruleset.
+   */
+  version: string;
+
+  /**
+   * An informative description of the ruleset.
+   */
+  description?: string;
+}
+
+export namespace VersionGetResponse {
+  export interface RulesetsChallengeRule {
+    /**
+     * The timestamp of when the rule was last modified.
+     */
+    last_updated: string;
+
+    /**
+     * The version of the rule.
+     */
+    version: string;
+
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * The categories of the rule.
+     */
+    categories?: Array<string>;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.Logging;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface RulesetsJSChallengeRule {
+    /**
+     * The timestamp of when the rule was last modified.
+     */
+    last_updated: string;
+
+    /**
+     * The version of the rule.
+     */
+    version: string;
+
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'js_challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * The categories of the rule.
+     */
+    categories?: Array<string>;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsJSChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.Logging;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsJSChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsJSChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+}
+
+export interface VersionListParams {
+  /**
+   * The Account ID to use for this endpoint. Mutually exclusive with the Zone ID.
+   */
+  account_id?: string;
+
+  /**
+   * The Zone ID to use for this endpoint. Mutually exclusive with the Account ID.
+   */
+  zone_id?: string;
+}
+
+export interface VersionGetParams {
+  /**
+   * The Account ID to use for this endpoint. Mutually exclusive with the Zone ID.
+   */
+  account_id?: string;
+
+  /**
+   * The Zone ID to use for this endpoint. Mutually exclusive with the Account ID.
+   */
+  zone_id?: string;
+}
+
+Versions.VersionListResponsesSinglePage = VersionListResponsesSinglePage;
+
+export declare namespace Versions {
+  export {
+    type VersionListResponse as VersionListResponse,
+    type VersionGetResponse as VersionGetResponse,
+    VersionListResponsesSinglePage as VersionListResponsesSinglePage,
+    type VersionListParams as VersionListParams,
+    type VersionGetParams as VersionGetParams,
+  };
+}

--- a/src/resources/rulesets/rules.ts
+++ b/src/resources/rulesets/rules.ts
@@ -1,9 +1,155 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';
+import { isRequestOptions } from '../../core';
+import * as Core from '../../core';
+import * as RulesAPI from './rules';
 import * as RulesetsAPI from './rulesets';
+import { CloudflareError } from '../../error';
 
-export class Rules extends APIResource {}
+export class Rules extends APIResource {
+  /**
+   * Adds a new rule to an account or zone ruleset. The rule will be added to the end
+   * of the existing list of rules in the ruleset by default.
+   *
+   * @example
+   * ```ts
+   * const rule = await client.rulesets.rules.create(
+   *   '2f2feab2026849078ba485f918791bdc',
+   *   { account_id: 'account_id' },
+   * );
+   * ```
+   */
+  create(
+    rulesetId: string,
+    params: RuleCreateParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<RuleCreateResponse> {
+    const { account_id, zone_id, ...body } = params;
+    if (!account_id && !zone_id) {
+      throw new CloudflareError('You must provide either account_id or zone_id.');
+    }
+    if (account_id && zone_id) {
+      throw new CloudflareError('You cannot provide both account_id and zone_id.');
+    }
+    const { accountOrZone, accountOrZoneId } =
+      account_id ?
+        {
+          accountOrZone: 'accounts',
+          accountOrZoneId: account_id,
+        }
+      : {
+          accountOrZone: 'zones',
+          accountOrZoneId: zone_id,
+        };
+    return (
+      this._client.post(`/${accountOrZone}/${accountOrZoneId}/rulesets/${rulesetId}/rules`, {
+        body,
+        ...options,
+      }) as Core.APIPromise<{ result: RuleCreateResponse }>
+    )._thenUnwrap((obj) => obj.result);
+  }
+
+  /**
+   * Deletes an existing rule from an account or zone ruleset.
+   *
+   * @example
+   * ```ts
+   * const rule = await client.rulesets.rules.delete(
+   *   '2f2feab2026849078ba485f918791bdc',
+   *   '3a03d665bac047339bb530ecb439a90d',
+   *   { account_id: 'account_id' },
+   * );
+   * ```
+   */
+  delete(
+    rulesetId: string,
+    ruleId: string,
+    params?: RuleDeleteParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<RuleDeleteResponse>;
+  delete(
+    rulesetId: string,
+    ruleId: string,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<RuleDeleteResponse>;
+  delete(
+    rulesetId: string,
+    ruleId: string,
+    params: RuleDeleteParams | Core.RequestOptions = {},
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<RuleDeleteResponse> {
+    if (isRequestOptions(params)) {
+      return this.delete(rulesetId, ruleId, {}, params);
+    }
+    const { account_id, zone_id } = params;
+    if (!account_id && !zone_id) {
+      throw new CloudflareError('You must provide either account_id or zone_id.');
+    }
+    if (account_id && zone_id) {
+      throw new CloudflareError('You cannot provide both account_id and zone_id.');
+    }
+    const { accountOrZone, accountOrZoneId } =
+      account_id ?
+        {
+          accountOrZone: 'accounts',
+          accountOrZoneId: account_id,
+        }
+      : {
+          accountOrZone: 'zones',
+          accountOrZoneId: zone_id,
+        };
+    return (
+      this._client.delete(
+        `/${accountOrZone}/${accountOrZoneId}/rulesets/${rulesetId}/rules/${ruleId}`,
+        options,
+      ) as Core.APIPromise<{ result: RuleDeleteResponse }>
+    )._thenUnwrap((obj) => obj.result);
+  }
+
+  /**
+   * Updates an existing rule in an account or zone ruleset.
+   *
+   * @example
+   * ```ts
+   * const response = await client.rulesets.rules.edit(
+   *   '2f2feab2026849078ba485f918791bdc',
+   *   '3a03d665bac047339bb530ecb439a90d',
+   *   { account_id: 'account_id' },
+   * );
+   * ```
+   */
+  edit(
+    rulesetId: string,
+    ruleId: string,
+    params: RuleEditParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<RuleEditResponse> {
+    const { account_id, zone_id, ...body } = params;
+    if (!account_id && !zone_id) {
+      throw new CloudflareError('You must provide either account_id or zone_id.');
+    }
+    if (account_id && zone_id) {
+      throw new CloudflareError('You cannot provide both account_id and zone_id.');
+    }
+    const { accountOrZone, accountOrZoneId } =
+      account_id ?
+        {
+          accountOrZone: 'accounts',
+          accountOrZoneId: account_id,
+        }
+      : {
+          accountOrZone: 'zones',
+          accountOrZoneId: zone_id,
+        };
+    return (
+      this._client.patch(`/${accountOrZone}/${accountOrZoneId}/rulesets/${rulesetId}/rules/${ruleId}`, {
+        body,
+        ...options,
+      }) as Core.APIPromise<{ result: RuleEditResponse }>
+    )._thenUnwrap((obj) => obj.result);
+  }
+}
 
 export interface BlockRule {
   /**
@@ -73,6 +219,158 @@ export interface BlockRule {
 }
 
 export namespace BlockRule {
+  /**
+   * The parameters configuring the rule's action.
+   */
+  export interface ActionParameters {
+    /**
+     * The response to show when the block is applied.
+     */
+    response?: ActionParameters.Response;
+  }
+
+  export namespace ActionParameters {
+    /**
+     * The response to show when the block is applied.
+     */
+    export interface Response {
+      /**
+       * The content to return.
+       */
+      content: string;
+
+      /**
+       * The type of the content to return.
+       */
+      content_type: string;
+
+      /**
+       * The status code to return.
+       */
+      status_code: number;
+    }
+  }
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  export interface ExposedCredentialCheck {
+    /**
+     * An expression that selects the password used in the credentials check.
+     */
+    password_expression: string;
+
+    /**
+     * An expression that selects the user ID used in the credentials check.
+     */
+    username_expression: string;
+  }
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  export interface Ratelimit {
+    /**
+     * Characteristics of the request on which the rate limit counter will be
+     * incremented.
+     */
+    characteristics: Array<string>;
+
+    /**
+     * Period in seconds over which the counter is being incremented.
+     */
+    period: number;
+
+    /**
+     * An expression that defines when the rate limit counter should be incremented. It
+     * defaults to the same as the rule's expression.
+     */
+    counting_expression?: string;
+
+    /**
+     * Period of time in seconds after which the action will be disabled following its
+     * first execution.
+     */
+    mitigation_timeout?: number;
+
+    /**
+     * The threshold of requests per period after which the action will be executed for
+     * the first time.
+     */
+    requests_per_period?: number;
+
+    /**
+     * Whether counting is only performed when an origin is reached.
+     */
+    requests_to_origin?: boolean;
+
+    /**
+     * The score threshold per period for which the action will be executed the first
+     * time.
+     */
+    score_per_period?: number;
+
+    /**
+     * A response header name provided by the origin, which contains the score to
+     * increment rate limit counter with.
+     */
+    score_response_header_name?: string;
+  }
+}
+
+export interface BlockRuleParam {
+  /**
+   * The unique ID of the rule.
+   */
+  id?: string;
+
+  /**
+   * The action to perform when the rule matches.
+   */
+  action?: 'block';
+
+  /**
+   * The parameters configuring the rule's action.
+   */
+  action_parameters?: BlockRuleParam.ActionParameters;
+
+  /**
+   * An informative description of the rule.
+   */
+  description?: string;
+
+  /**
+   * Whether the rule should be executed.
+   */
+  enabled?: boolean;
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  exposed_credential_check?: BlockRuleParam.ExposedCredentialCheck;
+
+  /**
+   * The expression defining which traffic will match the rule.
+   */
+  expression?: string;
+
+  /**
+   * An object configuring the rule's logging behavior.
+   */
+  logging?: LoggingParam;
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  ratelimit?: BlockRuleParam.Ratelimit;
+
+  /**
+   * The reference of the rule (the rule's ID by default).
+   */
+  ref?: string;
+}
+
+export namespace BlockRuleParam {
   /**
    * The parameters configuring the rule's action.
    */
@@ -329,6 +627,148 @@ export namespace CompressResponseRule {
   }
 }
 
+export interface CompressResponseRuleParam {
+  /**
+   * The unique ID of the rule.
+   */
+  id?: string;
+
+  /**
+   * The action to perform when the rule matches.
+   */
+  action?: 'compress_response';
+
+  /**
+   * The parameters configuring the rule's action.
+   */
+  action_parameters?: CompressResponseRuleParam.ActionParameters;
+
+  /**
+   * An informative description of the rule.
+   */
+  description?: string;
+
+  /**
+   * Whether the rule should be executed.
+   */
+  enabled?: boolean;
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  exposed_credential_check?: CompressResponseRuleParam.ExposedCredentialCheck;
+
+  /**
+   * The expression defining which traffic will match the rule.
+   */
+  expression?: string;
+
+  /**
+   * An object configuring the rule's logging behavior.
+   */
+  logging?: LoggingParam;
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  ratelimit?: CompressResponseRuleParam.Ratelimit;
+
+  /**
+   * The reference of the rule (the rule's ID by default).
+   */
+  ref?: string;
+}
+
+export namespace CompressResponseRuleParam {
+  /**
+   * The parameters configuring the rule's action.
+   */
+  export interface ActionParameters {
+    /**
+     * Custom order for compression algorithms.
+     */
+    algorithms: Array<ActionParameters.Algorithm>;
+  }
+
+  export namespace ActionParameters {
+    /**
+     * Compression algorithm to enable.
+     */
+    export interface Algorithm {
+      /**
+       * Name of the compression algorithm to enable.
+       */
+      name?: 'none' | 'auto' | 'default' | 'gzip' | 'brotli' | 'zstd';
+    }
+  }
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  export interface ExposedCredentialCheck {
+    /**
+     * An expression that selects the password used in the credentials check.
+     */
+    password_expression: string;
+
+    /**
+     * An expression that selects the user ID used in the credentials check.
+     */
+    username_expression: string;
+  }
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  export interface Ratelimit {
+    /**
+     * Characteristics of the request on which the rate limit counter will be
+     * incremented.
+     */
+    characteristics: Array<string>;
+
+    /**
+     * Period in seconds over which the counter is being incremented.
+     */
+    period: number;
+
+    /**
+     * An expression that defines when the rate limit counter should be incremented. It
+     * defaults to the same as the rule's expression.
+     */
+    counting_expression?: string;
+
+    /**
+     * Period of time in seconds after which the action will be disabled following its
+     * first execution.
+     */
+    mitigation_timeout?: number;
+
+    /**
+     * The threshold of requests per period after which the action will be executed for
+     * the first time.
+     */
+    requests_per_period?: number;
+
+    /**
+     * Whether counting is only performed when an origin is reached.
+     */
+    requests_to_origin?: boolean;
+
+    /**
+     * The score threshold per period for which the action will be executed the first
+     * time.
+     */
+    score_per_period?: number;
+
+    /**
+     * A response header name provided by the origin, which contains the score to
+     * increment rate limit counter with.
+     */
+    score_response_header_name?: string;
+  }
+}
+
 export interface DDoSDynamicRule {
   /**
    * The timestamp of when the rule was last modified.
@@ -397,6 +837,126 @@ export interface DDoSDynamicRule {
 }
 
 export namespace DDoSDynamicRule {
+  /**
+   * Configuration for exposed credential checking.
+   */
+  export interface ExposedCredentialCheck {
+    /**
+     * An expression that selects the password used in the credentials check.
+     */
+    password_expression: string;
+
+    /**
+     * An expression that selects the user ID used in the credentials check.
+     */
+    username_expression: string;
+  }
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  export interface Ratelimit {
+    /**
+     * Characteristics of the request on which the rate limit counter will be
+     * incremented.
+     */
+    characteristics: Array<string>;
+
+    /**
+     * Period in seconds over which the counter is being incremented.
+     */
+    period: number;
+
+    /**
+     * An expression that defines when the rate limit counter should be incremented. It
+     * defaults to the same as the rule's expression.
+     */
+    counting_expression?: string;
+
+    /**
+     * Period of time in seconds after which the action will be disabled following its
+     * first execution.
+     */
+    mitigation_timeout?: number;
+
+    /**
+     * The threshold of requests per period after which the action will be executed for
+     * the first time.
+     */
+    requests_per_period?: number;
+
+    /**
+     * Whether counting is only performed when an origin is reached.
+     */
+    requests_to_origin?: boolean;
+
+    /**
+     * The score threshold per period for which the action will be executed the first
+     * time.
+     */
+    score_per_period?: number;
+
+    /**
+     * A response header name provided by the origin, which contains the score to
+     * increment rate limit counter with.
+     */
+    score_response_header_name?: string;
+  }
+}
+
+export interface DDoSDynamicRuleParam {
+  /**
+   * The unique ID of the rule.
+   */
+  id?: string;
+
+  /**
+   * The action to perform when the rule matches.
+   */
+  action?: 'ddos_dynamic';
+
+  /**
+   * The parameters configuring the rule's action.
+   */
+  action_parameters?: unknown;
+
+  /**
+   * An informative description of the rule.
+   */
+  description?: string;
+
+  /**
+   * Whether the rule should be executed.
+   */
+  enabled?: boolean;
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  exposed_credential_check?: DDoSDynamicRuleParam.ExposedCredentialCheck;
+
+  /**
+   * The expression defining which traffic will match the rule.
+   */
+  expression?: string;
+
+  /**
+   * An object configuring the rule's logging behavior.
+   */
+  logging?: LoggingParam;
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  ratelimit?: DDoSDynamicRuleParam.Ratelimit;
+
+  /**
+   * The reference of the rule (the rule's ID by default).
+   */
+  ref?: string;
+}
+
+export namespace DDoSDynamicRuleParam {
   /**
    * Configuration for exposed credential checking.
    */
@@ -724,6 +1284,251 @@ export namespace ExecuteRule {
   }
 }
 
+export interface ExecuteRuleParam {
+  /**
+   * The unique ID of the rule.
+   */
+  id?: string;
+
+  /**
+   * The action to perform when the rule matches.
+   */
+  action?: 'execute';
+
+  /**
+   * The parameters configuring the rule's action.
+   */
+  action_parameters?: ExecuteRuleParam.ActionParameters;
+
+  /**
+   * An informative description of the rule.
+   */
+  description?: string;
+
+  /**
+   * Whether the rule should be executed.
+   */
+  enabled?: boolean;
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  exposed_credential_check?: ExecuteRuleParam.ExposedCredentialCheck;
+
+  /**
+   * The expression defining which traffic will match the rule.
+   */
+  expression?: string;
+
+  /**
+   * An object configuring the rule's logging behavior.
+   */
+  logging?: LoggingParam;
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  ratelimit?: ExecuteRuleParam.Ratelimit;
+
+  /**
+   * The reference of the rule (the rule's ID by default).
+   */
+  ref?: string;
+}
+
+export namespace ExecuteRuleParam {
+  /**
+   * The parameters configuring the rule's action.
+   */
+  export interface ActionParameters {
+    /**
+     * The ID of the ruleset to execute.
+     */
+    id: string;
+
+    /**
+     * The configuration to use for matched data logging.
+     */
+    matched_data?: ActionParameters.MatchedData;
+
+    /**
+     * A set of overrides to apply to the target ruleset.
+     */
+    overrides?: ActionParameters.Overrides;
+  }
+
+  export namespace ActionParameters {
+    /**
+     * The configuration to use for matched data logging.
+     */
+    export interface MatchedData {
+      /**
+       * The public key to encrypt matched data logs with.
+       */
+      public_key: string;
+    }
+
+    /**
+     * A set of overrides to apply to the target ruleset.
+     */
+    export interface Overrides {
+      /**
+       * An action to override all rules with. This option has lower precedence than rule
+       * and category overrides.
+       */
+      action?: string;
+
+      /**
+       * A list of category-level overrides. This option has the second-highest
+       * precedence after rule-level overrides.
+       */
+      categories?: Array<Overrides.Category>;
+
+      /**
+       * Whether to enable execution of all rules. This option has lower precedence than
+       * rule and category overrides.
+       */
+      enabled?: boolean;
+
+      /**
+       * A list of rule-level overrides. This option has the highest precedence.
+       */
+      rules?: Array<Overrides.Rule>;
+
+      /**
+       * A sensitivity level to set for all rules. This option has lower precedence than
+       * rule and category overrides and is only applicable for DDoS phases.
+       */
+      sensitivity_level?: 'default' | 'medium' | 'low' | 'eoff';
+    }
+
+    export namespace Overrides {
+      /**
+       * A category-level override.
+       */
+      export interface Category {
+        /**
+         * The name of the category to override.
+         */
+        category: string;
+
+        /**
+         * The action to override rules in the category with.
+         */
+        action?: string;
+
+        /**
+         * Whether to enable execution of rules in the category.
+         */
+        enabled?: boolean;
+
+        /**
+         * The sensitivity level to use for rules in the category. This option is only
+         * applicable for DDoS phases.
+         */
+        sensitivity_level?: 'default' | 'medium' | 'low' | 'eoff';
+      }
+
+      /**
+       * A rule-level override.
+       */
+      export interface Rule {
+        /**
+         * The ID of the rule to override.
+         */
+        id: string;
+
+        /**
+         * The action to override the rule with.
+         */
+        action?: string;
+
+        /**
+         * Whether to enable execution of the rule.
+         */
+        enabled?: boolean;
+
+        /**
+         * The score threshold to use for the rule.
+         */
+        score_threshold?: number;
+
+        /**
+         * The sensitivity level to use for the rule. This option is only applicable for
+         * DDoS phases.
+         */
+        sensitivity_level?: 'default' | 'medium' | 'low' | 'eoff';
+      }
+    }
+  }
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  export interface ExposedCredentialCheck {
+    /**
+     * An expression that selects the password used in the credentials check.
+     */
+    password_expression: string;
+
+    /**
+     * An expression that selects the user ID used in the credentials check.
+     */
+    username_expression: string;
+  }
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  export interface Ratelimit {
+    /**
+     * Characteristics of the request on which the rate limit counter will be
+     * incremented.
+     */
+    characteristics: Array<string>;
+
+    /**
+     * Period in seconds over which the counter is being incremented.
+     */
+    period: number;
+
+    /**
+     * An expression that defines when the rate limit counter should be incremented. It
+     * defaults to the same as the rule's expression.
+     */
+    counting_expression?: string;
+
+    /**
+     * Period of time in seconds after which the action will be disabled following its
+     * first execution.
+     */
+    mitigation_timeout?: number;
+
+    /**
+     * The threshold of requests per period after which the action will be executed for
+     * the first time.
+     */
+    requests_per_period?: number;
+
+    /**
+     * Whether counting is only performed when an origin is reached.
+     */
+    requests_to_origin?: boolean;
+
+    /**
+     * The score threshold per period for which the action will be executed the first
+     * time.
+     */
+    score_per_period?: number;
+
+    /**
+     * A response header name provided by the origin, which contains the score to
+     * increment rate limit counter with.
+     */
+    score_response_header_name?: string;
+  }
+}
+
 export interface ForceConnectionCloseRule {
   /**
    * The timestamp of when the rule was last modified.
@@ -792,6 +1597,126 @@ export interface ForceConnectionCloseRule {
 }
 
 export namespace ForceConnectionCloseRule {
+  /**
+   * Configuration for exposed credential checking.
+   */
+  export interface ExposedCredentialCheck {
+    /**
+     * An expression that selects the password used in the credentials check.
+     */
+    password_expression: string;
+
+    /**
+     * An expression that selects the user ID used in the credentials check.
+     */
+    username_expression: string;
+  }
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  export interface Ratelimit {
+    /**
+     * Characteristics of the request on which the rate limit counter will be
+     * incremented.
+     */
+    characteristics: Array<string>;
+
+    /**
+     * Period in seconds over which the counter is being incremented.
+     */
+    period: number;
+
+    /**
+     * An expression that defines when the rate limit counter should be incremented. It
+     * defaults to the same as the rule's expression.
+     */
+    counting_expression?: string;
+
+    /**
+     * Period of time in seconds after which the action will be disabled following its
+     * first execution.
+     */
+    mitigation_timeout?: number;
+
+    /**
+     * The threshold of requests per period after which the action will be executed for
+     * the first time.
+     */
+    requests_per_period?: number;
+
+    /**
+     * Whether counting is only performed when an origin is reached.
+     */
+    requests_to_origin?: boolean;
+
+    /**
+     * The score threshold per period for which the action will be executed the first
+     * time.
+     */
+    score_per_period?: number;
+
+    /**
+     * A response header name provided by the origin, which contains the score to
+     * increment rate limit counter with.
+     */
+    score_response_header_name?: string;
+  }
+}
+
+export interface ForceConnectionCloseRuleParam {
+  /**
+   * The unique ID of the rule.
+   */
+  id?: string;
+
+  /**
+   * The action to perform when the rule matches.
+   */
+  action?: 'force_connection_close';
+
+  /**
+   * The parameters configuring the rule's action.
+   */
+  action_parameters?: unknown;
+
+  /**
+   * An informative description of the rule.
+   */
+  description?: string;
+
+  /**
+   * Whether the rule should be executed.
+   */
+  enabled?: boolean;
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  exposed_credential_check?: ForceConnectionCloseRuleParam.ExposedCredentialCheck;
+
+  /**
+   * The expression defining which traffic will match the rule.
+   */
+  expression?: string;
+
+  /**
+   * An object configuring the rule's logging behavior.
+   */
+  logging?: LoggingParam;
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  ratelimit?: ForceConnectionCloseRuleParam.Ratelimit;
+
+  /**
+   * The reference of the rule (the rule's ID by default).
+   */
+  ref?: string;
+}
+
+export namespace ForceConnectionCloseRuleParam {
   /**
    * Configuration for exposed credential checking.
    */
@@ -1086,6 +2011,218 @@ export namespace LogCustomFieldRule {
   }
 }
 
+export interface LogCustomFieldRuleParam {
+  /**
+   * The unique ID of the rule.
+   */
+  id?: string;
+
+  /**
+   * The action to perform when the rule matches.
+   */
+  action?: 'log_custom_field';
+
+  /**
+   * The parameters configuring the rule's action.
+   */
+  action_parameters?: LogCustomFieldRuleParam.ActionParameters;
+
+  /**
+   * An informative description of the rule.
+   */
+  description?: string;
+
+  /**
+   * Whether the rule should be executed.
+   */
+  enabled?: boolean;
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  exposed_credential_check?: LogCustomFieldRuleParam.ExposedCredentialCheck;
+
+  /**
+   * The expression defining which traffic will match the rule.
+   */
+  expression?: string;
+
+  /**
+   * An object configuring the rule's logging behavior.
+   */
+  logging?: LoggingParam;
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  ratelimit?: LogCustomFieldRuleParam.Ratelimit;
+
+  /**
+   * The reference of the rule (the rule's ID by default).
+   */
+  ref?: string;
+}
+
+export namespace LogCustomFieldRuleParam {
+  /**
+   * The parameters configuring the rule's action.
+   */
+  export interface ActionParameters {
+    /**
+     * The cookie fields to log.
+     */
+    cookie_fields?: Array<ActionParameters.CookieField>;
+
+    /**
+     * The raw response fields to log.
+     */
+    raw_response_fields?: Array<ActionParameters.RawResponseField>;
+
+    /**
+     * The raw request fields to log.
+     */
+    request_fields?: Array<ActionParameters.RequestField>;
+
+    /**
+     * The transformed response fields to log.
+     */
+    response_fields?: Array<ActionParameters.ResponseField>;
+
+    /**
+     * The transformed request fields to log.
+     */
+    transformed_request_fields?: Array<ActionParameters.TransformedRequestField>;
+  }
+
+  export namespace ActionParameters {
+    /**
+     * The cookie field to log.
+     */
+    export interface CookieField {
+      /**
+       * The name of the cookie.
+       */
+      name: string;
+    }
+
+    /**
+     * The raw response field to log.
+     */
+    export interface RawResponseField {
+      /**
+       * The name of the response header.
+       */
+      name: string;
+
+      /**
+       * Whether to log duplicate values of the same header.
+       */
+      preserve_duplicates?: boolean;
+    }
+
+    /**
+     * The raw request field to log.
+     */
+    export interface RequestField {
+      /**
+       * The name of the header.
+       */
+      name: string;
+    }
+
+    /**
+     * The transformed response field to log.
+     */
+    export interface ResponseField {
+      /**
+       * The name of the response header.
+       */
+      name: string;
+
+      /**
+       * Whether to log duplicate values of the same header.
+       */
+      preserve_duplicates?: boolean;
+    }
+
+    /**
+     * The transformed request field to log.
+     */
+    export interface TransformedRequestField {
+      /**
+       * The name of the header.
+       */
+      name: string;
+    }
+  }
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  export interface ExposedCredentialCheck {
+    /**
+     * An expression that selects the password used in the credentials check.
+     */
+    password_expression: string;
+
+    /**
+     * An expression that selects the user ID used in the credentials check.
+     */
+    username_expression: string;
+  }
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  export interface Ratelimit {
+    /**
+     * Characteristics of the request on which the rate limit counter will be
+     * incremented.
+     */
+    characteristics: Array<string>;
+
+    /**
+     * Period in seconds over which the counter is being incremented.
+     */
+    period: number;
+
+    /**
+     * An expression that defines when the rate limit counter should be incremented. It
+     * defaults to the same as the rule's expression.
+     */
+    counting_expression?: string;
+
+    /**
+     * Period of time in seconds after which the action will be disabled following its
+     * first execution.
+     */
+    mitigation_timeout?: number;
+
+    /**
+     * The threshold of requests per period after which the action will be executed for
+     * the first time.
+     */
+    requests_per_period?: number;
+
+    /**
+     * Whether counting is only performed when an origin is reached.
+     */
+    requests_to_origin?: boolean;
+
+    /**
+     * The score threshold per period for which the action will be executed the first
+     * time.
+     */
+    score_per_period?: number;
+
+    /**
+     * A response header name provided by the origin, which contains the score to
+     * increment rate limit counter with.
+     */
+    score_response_header_name?: string;
+  }
+}
+
 export interface LogRule {
   /**
    * The timestamp of when the rule was last modified.
@@ -1221,10 +2358,140 @@ export namespace LogRule {
   }
 }
 
+export interface LogRuleParam {
+  /**
+   * The unique ID of the rule.
+   */
+  id?: string;
+
+  /**
+   * The action to perform when the rule matches.
+   */
+  action?: 'log';
+
+  /**
+   * The parameters configuring the rule's action.
+   */
+  action_parameters?: unknown;
+
+  /**
+   * An informative description of the rule.
+   */
+  description?: string;
+
+  /**
+   * Whether the rule should be executed.
+   */
+  enabled?: boolean;
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  exposed_credential_check?: LogRuleParam.ExposedCredentialCheck;
+
+  /**
+   * The expression defining which traffic will match the rule.
+   */
+  expression?: string;
+
+  /**
+   * An object configuring the rule's logging behavior.
+   */
+  logging?: LoggingParam;
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  ratelimit?: LogRuleParam.Ratelimit;
+
+  /**
+   * The reference of the rule (the rule's ID by default).
+   */
+  ref?: string;
+}
+
+export namespace LogRuleParam {
+  /**
+   * Configuration for exposed credential checking.
+   */
+  export interface ExposedCredentialCheck {
+    /**
+     * An expression that selects the password used in the credentials check.
+     */
+    password_expression: string;
+
+    /**
+     * An expression that selects the user ID used in the credentials check.
+     */
+    username_expression: string;
+  }
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  export interface Ratelimit {
+    /**
+     * Characteristics of the request on which the rate limit counter will be
+     * incremented.
+     */
+    characteristics: Array<string>;
+
+    /**
+     * Period in seconds over which the counter is being incremented.
+     */
+    period: number;
+
+    /**
+     * An expression that defines when the rate limit counter should be incremented. It
+     * defaults to the same as the rule's expression.
+     */
+    counting_expression?: string;
+
+    /**
+     * Period of time in seconds after which the action will be disabled following its
+     * first execution.
+     */
+    mitigation_timeout?: number;
+
+    /**
+     * The threshold of requests per period after which the action will be executed for
+     * the first time.
+     */
+    requests_per_period?: number;
+
+    /**
+     * Whether counting is only performed when an origin is reached.
+     */
+    requests_to_origin?: boolean;
+
+    /**
+     * The score threshold per period for which the action will be executed the first
+     * time.
+     */
+    score_per_period?: number;
+
+    /**
+     * A response header name provided by the origin, which contains the score to
+     * increment rate limit counter with.
+     */
+    score_response_header_name?: string;
+  }
+}
+
 /**
  * An object configuring the rule's logging behavior.
  */
 export interface Logging {
+  /**
+   * Whether to generate a log when the rule matches.
+   */
+  enabled: boolean;
+}
+
+/**
+ * An object configuring the rule's logging behavior.
+ */
+export interface LoggingParam {
   /**
    * Whether to generate a log when the rule matches.
    */
@@ -1366,6 +2633,126 @@ export namespace ManagedChallengeRule {
   }
 }
 
+export interface ManagedChallengeRuleParam {
+  /**
+   * The unique ID of the rule.
+   */
+  id?: string;
+
+  /**
+   * The action to perform when the rule matches.
+   */
+  action?: 'managed_challenge';
+
+  /**
+   * The parameters configuring the rule's action.
+   */
+  action_parameters?: unknown;
+
+  /**
+   * An informative description of the rule.
+   */
+  description?: string;
+
+  /**
+   * Whether the rule should be executed.
+   */
+  enabled?: boolean;
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  exposed_credential_check?: ManagedChallengeRuleParam.ExposedCredentialCheck;
+
+  /**
+   * The expression defining which traffic will match the rule.
+   */
+  expression?: string;
+
+  /**
+   * An object configuring the rule's logging behavior.
+   */
+  logging?: LoggingParam;
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  ratelimit?: ManagedChallengeRuleParam.Ratelimit;
+
+  /**
+   * The reference of the rule (the rule's ID by default).
+   */
+  ref?: string;
+}
+
+export namespace ManagedChallengeRuleParam {
+  /**
+   * Configuration for exposed credential checking.
+   */
+  export interface ExposedCredentialCheck {
+    /**
+     * An expression that selects the password used in the credentials check.
+     */
+    password_expression: string;
+
+    /**
+     * An expression that selects the user ID used in the credentials check.
+     */
+    username_expression: string;
+  }
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  export interface Ratelimit {
+    /**
+     * Characteristics of the request on which the rate limit counter will be
+     * incremented.
+     */
+    characteristics: Array<string>;
+
+    /**
+     * Period in seconds over which the counter is being incremented.
+     */
+    period: number;
+
+    /**
+     * An expression that defines when the rate limit counter should be incremented. It
+     * defaults to the same as the rule's expression.
+     */
+    counting_expression?: string;
+
+    /**
+     * Period of time in seconds after which the action will be disabled following its
+     * first execution.
+     */
+    mitigation_timeout?: number;
+
+    /**
+     * The threshold of requests per period after which the action will be executed for
+     * the first time.
+     */
+    requests_per_period?: number;
+
+    /**
+     * Whether counting is only performed when an origin is reached.
+     */
+    requests_to_origin?: boolean;
+
+    /**
+     * The score threshold per period for which the action will be executed the first
+     * time.
+     */
+    score_per_period?: number;
+
+    /**
+     * A response header name provided by the origin, which contains the score to
+     * increment rate limit counter with.
+     */
+    score_response_header_name?: string;
+  }
+}
+
 export interface RedirectRule {
   /**
    * The timestamp of when the rule was last modified.
@@ -1434,6 +2821,195 @@ export interface RedirectRule {
 }
 
 export namespace RedirectRule {
+  /**
+   * The parameters configuring the rule's action.
+   */
+  export interface ActionParameters {
+    /**
+     * A redirect based on a bulk list lookup.
+     */
+    from_list?: ActionParameters.FromList;
+
+    /**
+     * A redirect based on the request properties.
+     */
+    from_value?: ActionParameters.FromValue;
+  }
+
+  export namespace ActionParameters {
+    /**
+     * A redirect based on a bulk list lookup.
+     */
+    export interface FromList {
+      /**
+       * An expression that evaluates to the list lookup key.
+       */
+      key: string;
+
+      /**
+       * The name of the list to match against.
+       */
+      name: string;
+    }
+
+    /**
+     * A redirect based on the request properties.
+     */
+    export interface FromValue {
+      /**
+       * A URL to redirect the request to.
+       */
+      target_url: FromValue.TargetURL;
+
+      /**
+       * Whether to keep the query string of the original request.
+       */
+      preserve_query_string?: boolean;
+
+      /**
+       * The status code to use for the redirect.
+       */
+      status_code?: 301 | 302 | 303 | 307 | 308;
+    }
+
+    export namespace FromValue {
+      /**
+       * A URL to redirect the request to.
+       */
+      export interface TargetURL {
+        /**
+         * An expression that evaluates to a URL to redirect the request to.
+         */
+        expression?: string;
+
+        /**
+         * A URL to redirect the request to.
+         */
+        value?: string;
+      }
+    }
+  }
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  export interface ExposedCredentialCheck {
+    /**
+     * An expression that selects the password used in the credentials check.
+     */
+    password_expression: string;
+
+    /**
+     * An expression that selects the user ID used in the credentials check.
+     */
+    username_expression: string;
+  }
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  export interface Ratelimit {
+    /**
+     * Characteristics of the request on which the rate limit counter will be
+     * incremented.
+     */
+    characteristics: Array<string>;
+
+    /**
+     * Period in seconds over which the counter is being incremented.
+     */
+    period: number;
+
+    /**
+     * An expression that defines when the rate limit counter should be incremented. It
+     * defaults to the same as the rule's expression.
+     */
+    counting_expression?: string;
+
+    /**
+     * Period of time in seconds after which the action will be disabled following its
+     * first execution.
+     */
+    mitigation_timeout?: number;
+
+    /**
+     * The threshold of requests per period after which the action will be executed for
+     * the first time.
+     */
+    requests_per_period?: number;
+
+    /**
+     * Whether counting is only performed when an origin is reached.
+     */
+    requests_to_origin?: boolean;
+
+    /**
+     * The score threshold per period for which the action will be executed the first
+     * time.
+     */
+    score_per_period?: number;
+
+    /**
+     * A response header name provided by the origin, which contains the score to
+     * increment rate limit counter with.
+     */
+    score_response_header_name?: string;
+  }
+}
+
+export interface RedirectRuleParam {
+  /**
+   * The unique ID of the rule.
+   */
+  id?: string;
+
+  /**
+   * The action to perform when the rule matches.
+   */
+  action?: 'redirect';
+
+  /**
+   * The parameters configuring the rule's action.
+   */
+  action_parameters?: RedirectRuleParam.ActionParameters;
+
+  /**
+   * An informative description of the rule.
+   */
+  description?: string;
+
+  /**
+   * Whether the rule should be executed.
+   */
+  enabled?: boolean;
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  exposed_credential_check?: RedirectRuleParam.ExposedCredentialCheck;
+
+  /**
+   * The expression defining which traffic will match the rule.
+   */
+  expression?: string;
+
+  /**
+   * An object configuring the rule's logging behavior.
+   */
+  logging?: LoggingParam;
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  ratelimit?: RedirectRuleParam.Ratelimit;
+
+  /**
+   * The reference of the rule (the rule's ID by default).
+   */
+  ref?: string;
+}
+
+export namespace RedirectRuleParam {
   /**
    * The parameters configuring the rule's action.
    */
@@ -1863,6 +3439,274 @@ export namespace RewriteRule {
   }
 }
 
+export interface RewriteRuleParam {
+  /**
+   * The unique ID of the rule.
+   */
+  id?: string;
+
+  /**
+   * The action to perform when the rule matches.
+   */
+  action?: 'rewrite';
+
+  /**
+   * The parameters configuring the rule's action.
+   */
+  action_parameters?: RewriteRuleParam.ActionParameters;
+
+  /**
+   * An informative description of the rule.
+   */
+  description?: string;
+
+  /**
+   * Whether the rule should be executed.
+   */
+  enabled?: boolean;
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  exposed_credential_check?: RewriteRuleParam.ExposedCredentialCheck;
+
+  /**
+   * The expression defining which traffic will match the rule.
+   */
+  expression?: string;
+
+  /**
+   * An object configuring the rule's logging behavior.
+   */
+  logging?: LoggingParam;
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  ratelimit?: RewriteRuleParam.Ratelimit;
+
+  /**
+   * The reference of the rule (the rule's ID by default).
+   */
+  ref?: string;
+}
+
+export namespace RewriteRuleParam {
+  /**
+   * The parameters configuring the rule's action.
+   */
+  export interface ActionParameters {
+    /**
+     * A map of headers to rewrite.
+     */
+    headers?: {
+      [key: string]:
+        | ActionParameters.AddStaticHeader
+        | ActionParameters.AddDynamicHeader
+        | ActionParameters.SetStaticHeader
+        | ActionParameters.SetDynamicHeader
+        | ActionParameters.RemoveHeader;
+    };
+
+    /**
+     * A URI path rewrite.
+     */
+    uri?: ActionParameters.URIPath | ActionParameters.URIQuery;
+  }
+
+  export namespace ActionParameters {
+    /**
+     * A header with a static value to add.
+     */
+    export interface AddStaticHeader {
+      /**
+       * The operation to perform on the header.
+       */
+      operation: 'add';
+
+      /**
+       * A static value for the header.
+       */
+      value: string;
+    }
+
+    /**
+     * A header with a dynamic value to add.
+     */
+    export interface AddDynamicHeader {
+      /**
+       * An expression that evaluates to a value for the header.
+       */
+      expression: string;
+
+      /**
+       * The operation to perform on the header.
+       */
+      operation: 'add';
+    }
+
+    /**
+     * A header with a static value to set.
+     */
+    export interface SetStaticHeader {
+      /**
+       * The operation to perform on the header.
+       */
+      operation: 'set';
+
+      /**
+       * A static value for the header.
+       */
+      value: string;
+    }
+
+    /**
+     * A header with a dynamic value to set.
+     */
+    export interface SetDynamicHeader {
+      /**
+       * An expression that evaluates to a value for the header.
+       */
+      expression: string;
+
+      /**
+       * The operation to perform on the header.
+       */
+      operation: 'set';
+    }
+
+    /**
+     * A header to remove.
+     */
+    export interface RemoveHeader {
+      /**
+       * The operation to perform on the header.
+       */
+      operation: 'remove';
+    }
+
+    /**
+     * A URI path rewrite.
+     */
+    export interface URIPath {
+      /**
+       * A URI path rewrite.
+       */
+      path: URIPath.Path;
+    }
+
+    export namespace URIPath {
+      /**
+       * A URI path rewrite.
+       */
+      export interface Path {
+        /**
+         * An expression that evaluates to a value to rewrite the URI path to.
+         */
+        expression?: string;
+
+        /**
+         * A value to rewrite the URI path to.
+         */
+        value?: string;
+      }
+    }
+
+    /**
+     * A URI query rewrite.
+     */
+    export interface URIQuery {
+      /**
+       * A URI query rewrite.
+       */
+      query: URIQuery.Query;
+    }
+
+    export namespace URIQuery {
+      /**
+       * A URI query rewrite.
+       */
+      export interface Query {
+        /**
+         * An expression that evaluates to a value to rewrite the URI query to.
+         */
+        expression?: string;
+
+        /**
+         * A value to rewrite the URI query to.
+         */
+        value?: string;
+      }
+    }
+  }
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  export interface ExposedCredentialCheck {
+    /**
+     * An expression that selects the password used in the credentials check.
+     */
+    password_expression: string;
+
+    /**
+     * An expression that selects the user ID used in the credentials check.
+     */
+    username_expression: string;
+  }
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  export interface Ratelimit {
+    /**
+     * Characteristics of the request on which the rate limit counter will be
+     * incremented.
+     */
+    characteristics: Array<string>;
+
+    /**
+     * Period in seconds over which the counter is being incremented.
+     */
+    period: number;
+
+    /**
+     * An expression that defines when the rate limit counter should be incremented. It
+     * defaults to the same as the rule's expression.
+     */
+    counting_expression?: string;
+
+    /**
+     * Period of time in seconds after which the action will be disabled following its
+     * first execution.
+     */
+    mitigation_timeout?: number;
+
+    /**
+     * The threshold of requests per period after which the action will be executed for
+     * the first time.
+     */
+    requests_per_period?: number;
+
+    /**
+     * Whether counting is only performed when an origin is reached.
+     */
+    requests_to_origin?: boolean;
+
+    /**
+     * The score threshold per period for which the action will be executed the first
+     * time.
+     */
+    score_per_period?: number;
+
+    /**
+     * A response header name provided by the origin, which contains the score to
+     * increment rate limit counter with.
+     */
+    score_response_header_name?: string;
+  }
+}
+
 export interface RouteRule {
   /**
    * The timestamp of when the rule was last modified.
@@ -1931,6 +3775,173 @@ export interface RouteRule {
 }
 
 export namespace RouteRule {
+  /**
+   * The parameters configuring the rule's action.
+   */
+  export interface ActionParameters {
+    /**
+     * A value to rewrite the HTTP host header to.
+     */
+    host_header?: string;
+
+    /**
+     * An origin to route to.
+     */
+    origin?: ActionParameters.Origin;
+
+    /**
+     * A Server Name Indication (SNI) override.
+     */
+    sni?: ActionParameters.SNI;
+  }
+
+  export namespace ActionParameters {
+    /**
+     * An origin to route to.
+     */
+    export interface Origin {
+      /**
+       * A resolved host to route to.
+       */
+      host?: string;
+
+      /**
+       * A destination port to route to.
+       */
+      port?: number;
+    }
+
+    /**
+     * A Server Name Indication (SNI) override.
+     */
+    export interface SNI {
+      /**
+       * A value to override the SNI to.
+       */
+      value: string;
+    }
+  }
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  export interface ExposedCredentialCheck {
+    /**
+     * An expression that selects the password used in the credentials check.
+     */
+    password_expression: string;
+
+    /**
+     * An expression that selects the user ID used in the credentials check.
+     */
+    username_expression: string;
+  }
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  export interface Ratelimit {
+    /**
+     * Characteristics of the request on which the rate limit counter will be
+     * incremented.
+     */
+    characteristics: Array<string>;
+
+    /**
+     * Period in seconds over which the counter is being incremented.
+     */
+    period: number;
+
+    /**
+     * An expression that defines when the rate limit counter should be incremented. It
+     * defaults to the same as the rule's expression.
+     */
+    counting_expression?: string;
+
+    /**
+     * Period of time in seconds after which the action will be disabled following its
+     * first execution.
+     */
+    mitigation_timeout?: number;
+
+    /**
+     * The threshold of requests per period after which the action will be executed for
+     * the first time.
+     */
+    requests_per_period?: number;
+
+    /**
+     * Whether counting is only performed when an origin is reached.
+     */
+    requests_to_origin?: boolean;
+
+    /**
+     * The score threshold per period for which the action will be executed the first
+     * time.
+     */
+    score_per_period?: number;
+
+    /**
+     * A response header name provided by the origin, which contains the score to
+     * increment rate limit counter with.
+     */
+    score_response_header_name?: string;
+  }
+}
+
+export interface RouteRuleParam {
+  /**
+   * The unique ID of the rule.
+   */
+  id?: string;
+
+  /**
+   * The action to perform when the rule matches.
+   */
+  action?: 'route';
+
+  /**
+   * The parameters configuring the rule's action.
+   */
+  action_parameters?: RouteRuleParam.ActionParameters;
+
+  /**
+   * An informative description of the rule.
+   */
+  description?: string;
+
+  /**
+   * Whether the rule should be executed.
+   */
+  enabled?: boolean;
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  exposed_credential_check?: RouteRuleParam.ExposedCredentialCheck;
+
+  /**
+   * The expression defining which traffic will match the rule.
+   */
+  expression?: string;
+
+  /**
+   * An object configuring the rule's logging behavior.
+   */
+  logging?: LoggingParam;
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  ratelimit?: RouteRuleParam.Ratelimit;
+
+  /**
+   * The reference of the rule (the rule's ID by default).
+   */
+  ref?: string;
+}
+
+export namespace RouteRuleParam {
   /**
    * The parameters configuring the rule's action.
    */
@@ -2325,6 +4336,136 @@ export namespace ScoreRule {
   }
 }
 
+export interface ScoreRuleParam {
+  /**
+   * The unique ID of the rule.
+   */
+  id?: string;
+
+  /**
+   * The action to perform when the rule matches.
+   */
+  action?: 'score';
+
+  /**
+   * The parameters configuring the rule's action.
+   */
+  action_parameters?: ScoreRuleParam.ActionParameters;
+
+  /**
+   * An informative description of the rule.
+   */
+  description?: string;
+
+  /**
+   * Whether the rule should be executed.
+   */
+  enabled?: boolean;
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  exposed_credential_check?: ScoreRuleParam.ExposedCredentialCheck;
+
+  /**
+   * The expression defining which traffic will match the rule.
+   */
+  expression?: string;
+
+  /**
+   * An object configuring the rule's logging behavior.
+   */
+  logging?: LoggingParam;
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  ratelimit?: ScoreRuleParam.Ratelimit;
+
+  /**
+   * The reference of the rule (the rule's ID by default).
+   */
+  ref?: string;
+}
+
+export namespace ScoreRuleParam {
+  /**
+   * The parameters configuring the rule's action.
+   */
+  export interface ActionParameters {
+    /**
+     * A delta to change the score by, which can be either positive or negative.
+     */
+    increment: number;
+  }
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  export interface ExposedCredentialCheck {
+    /**
+     * An expression that selects the password used in the credentials check.
+     */
+    password_expression: string;
+
+    /**
+     * An expression that selects the user ID used in the credentials check.
+     */
+    username_expression: string;
+  }
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  export interface Ratelimit {
+    /**
+     * Characteristics of the request on which the rate limit counter will be
+     * incremented.
+     */
+    characteristics: Array<string>;
+
+    /**
+     * Period in seconds over which the counter is being incremented.
+     */
+    period: number;
+
+    /**
+     * An expression that defines when the rate limit counter should be incremented. It
+     * defaults to the same as the rule's expression.
+     */
+    counting_expression?: string;
+
+    /**
+     * Period of time in seconds after which the action will be disabled following its
+     * first execution.
+     */
+    mitigation_timeout?: number;
+
+    /**
+     * The threshold of requests per period after which the action will be executed for
+     * the first time.
+     */
+    requests_per_period?: number;
+
+    /**
+     * Whether counting is only performed when an origin is reached.
+     */
+    requests_to_origin?: boolean;
+
+    /**
+     * The score threshold per period for which the action will be executed the first
+     * time.
+     */
+    score_per_period?: number;
+
+    /**
+     * A response header name provided by the origin, which contains the score to
+     * increment rate limit counter with.
+     */
+    score_response_header_name?: string;
+  }
+}
+
 export interface ServeErrorRule {
   /**
    * The timestamp of when the rule was last modified.
@@ -2393,6 +4534,160 @@ export interface ServeErrorRule {
 }
 
 export namespace ServeErrorRule {
+  export interface ActionParametersContent {
+    /**
+     * The response content.
+     */
+    content: string;
+
+    /**
+     * The content type header to set with the error response.
+     */
+    content_type?: 'application/json' | 'text/html' | 'text/plain' | 'text/xml';
+
+    /**
+     * The status code to use for the error.
+     */
+    status_code?: number;
+  }
+
+  export interface ActionParametersAsset {
+    /**
+     * The name of a custom asset to serve as the error response.
+     */
+    asset_name: string;
+
+    /**
+     * The content type header to set with the error response.
+     */
+    content_type?: 'application/json' | 'text/html' | 'text/plain' | 'text/xml';
+
+    /**
+     * The status code to use for the error.
+     */
+    status_code?: number;
+  }
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  export interface ExposedCredentialCheck {
+    /**
+     * An expression that selects the password used in the credentials check.
+     */
+    password_expression: string;
+
+    /**
+     * An expression that selects the user ID used in the credentials check.
+     */
+    username_expression: string;
+  }
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  export interface Ratelimit {
+    /**
+     * Characteristics of the request on which the rate limit counter will be
+     * incremented.
+     */
+    characteristics: Array<string>;
+
+    /**
+     * Period in seconds over which the counter is being incremented.
+     */
+    period: number;
+
+    /**
+     * An expression that defines when the rate limit counter should be incremented. It
+     * defaults to the same as the rule's expression.
+     */
+    counting_expression?: string;
+
+    /**
+     * Period of time in seconds after which the action will be disabled following its
+     * first execution.
+     */
+    mitigation_timeout?: number;
+
+    /**
+     * The threshold of requests per period after which the action will be executed for
+     * the first time.
+     */
+    requests_per_period?: number;
+
+    /**
+     * Whether counting is only performed when an origin is reached.
+     */
+    requests_to_origin?: boolean;
+
+    /**
+     * The score threshold per period for which the action will be executed the first
+     * time.
+     */
+    score_per_period?: number;
+
+    /**
+     * A response header name provided by the origin, which contains the score to
+     * increment rate limit counter with.
+     */
+    score_response_header_name?: string;
+  }
+}
+
+export interface ServeErrorRuleParam {
+  /**
+   * The unique ID of the rule.
+   */
+  id?: string;
+
+  /**
+   * The action to perform when the rule matches.
+   */
+  action?: 'serve_error';
+
+  /**
+   * The parameters configuring the rule's action.
+   */
+  action_parameters?: ServeErrorRuleParam.ActionParametersContent | ServeErrorRuleParam.ActionParametersAsset;
+
+  /**
+   * An informative description of the rule.
+   */
+  description?: string;
+
+  /**
+   * Whether the rule should be executed.
+   */
+  enabled?: boolean;
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  exposed_credential_check?: ServeErrorRuleParam.ExposedCredentialCheck;
+
+  /**
+   * The expression defining which traffic will match the rule.
+   */
+  expression?: string;
+
+  /**
+   * An object configuring the rule's logging behavior.
+   */
+  logging?: LoggingParam;
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  ratelimit?: ServeErrorRuleParam.Ratelimit;
+
+  /**
+   * The reference of the rule (the rule's ID by default).
+   */
+  ref?: string;
+}
+
+export namespace ServeErrorRuleParam {
   export interface ActionParametersContent {
     /**
      * The response content.
@@ -2631,27 +4926,6 @@ export namespace SetCacheSettingsRule {
      * When to serve stale content from cache.
      */
     serve_stale?: ActionParameters.ServeStale;
-
-    /**
-     * Configuration for shared dictionary compression. When set, Cloudflare injects
-     * Use-As-Dictionary headers on matching cacheable responses.
-     */
-    shared_dictionary?: ActionParameters.SharedDictionary;
-
-    /**
-     * Whether to strip ETag headers from the origin response before caching.
-     */
-    strip_etags?: boolean;
-
-    /**
-     * Whether to strip Last-Modified headers from the origin response before caching.
-     */
-    strip_last_modified?: boolean;
-
-    /**
-     * Whether to strip Set-Cookie headers from the origin response before caching.
-     */
-    strip_set_cookie?: boolean;
   }
 
   export namespace ActionParameters {
@@ -2940,17 +5214,484 @@ export namespace SetCacheSettingsRule {
        */
       disable_stale_while_updating?: boolean;
     }
+  }
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  export interface ExposedCredentialCheck {
+    /**
+     * An expression that selects the password used in the credentials check.
+     */
+    password_expression: string;
 
     /**
-     * Configuration for shared dictionary compression. When set, Cloudflare injects
-     * Use-As-Dictionary headers on matching cacheable responses.
+     * An expression that selects the user ID used in the credentials check.
      */
-    export interface SharedDictionary {
+    username_expression: string;
+  }
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  export interface Ratelimit {
+    /**
+     * Characteristics of the request on which the rate limit counter will be
+     * incremented.
+     */
+    characteristics: Array<string>;
+
+    /**
+     * Period in seconds over which the counter is being incremented.
+     */
+    period: number;
+
+    /**
+     * An expression that defines when the rate limit counter should be incremented. It
+     * defaults to the same as the rule's expression.
+     */
+    counting_expression?: string;
+
+    /**
+     * Period of time in seconds after which the action will be disabled following its
+     * first execution.
+     */
+    mitigation_timeout?: number;
+
+    /**
+     * The threshold of requests per period after which the action will be executed for
+     * the first time.
+     */
+    requests_per_period?: number;
+
+    /**
+     * Whether counting is only performed when an origin is reached.
+     */
+    requests_to_origin?: boolean;
+
+    /**
+     * The score threshold per period for which the action will be executed the first
+     * time.
+     */
+    score_per_period?: number;
+
+    /**
+     * A response header name provided by the origin, which contains the score to
+     * increment rate limit counter with.
+     */
+    score_response_header_name?: string;
+  }
+}
+
+export interface SetCacheSettingsRuleParam {
+  /**
+   * The unique ID of the rule.
+   */
+  id?: string;
+
+  /**
+   * The action to perform when the rule matches.
+   */
+  action?: 'set_cache_settings';
+
+  /**
+   * The parameters configuring the rule's action.
+   */
+  action_parameters?: SetCacheSettingsRuleParam.ActionParameters;
+
+  /**
+   * An informative description of the rule.
+   */
+  description?: string;
+
+  /**
+   * Whether the rule should be executed.
+   */
+  enabled?: boolean;
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  exposed_credential_check?: SetCacheSettingsRuleParam.ExposedCredentialCheck;
+
+  /**
+   * The expression defining which traffic will match the rule.
+   */
+  expression?: string;
+
+  /**
+   * An object configuring the rule's logging behavior.
+   */
+  logging?: LoggingParam;
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  ratelimit?: SetCacheSettingsRuleParam.Ratelimit;
+
+  /**
+   * The reference of the rule (the rule's ID by default).
+   */
+  ref?: string;
+}
+
+export namespace SetCacheSettingsRuleParam {
+  /**
+   * The parameters configuring the rule's action.
+   */
+  export interface ActionParameters {
+    /**
+     * A list of additional ports that caching should be enabled on.
+     */
+    additional_cacheable_ports?: Array<number>;
+
+    /**
+     * How long client browsers should cache the response. Cloudflare cache purge will
+     * not purge content cached on client browsers, so high browser TTLs may lead to
+     * stale content.
+     */
+    browser_ttl?: ActionParameters.BrowserTTL;
+
+    /**
+     * Whether the request's response from the origin is eligible for caching. Caching
+     * itself will still depend on the cache control header and your other caching
+     * configurations.
+     */
+    cache?: boolean;
+
+    /**
+     * Which components of the request are included in or excluded from the cache key
+     * Cloudflare uses to store the response in cache.
+     */
+    cache_key?: ActionParameters.CacheKey;
+
+    /**
+     * Settings to determine whether the request's response from origin is eligible for
+     * Cache Reserve (requires a Cache Reserve add-on plan).
+     */
+    cache_reserve?: ActionParameters.CacheReserve;
+
+    /**
+     * How long the Cloudflare edge network should cache the response.
+     */
+    edge_ttl?: ActionParameters.EdgeTTL;
+
+    /**
+     * Whether Cloudflare will aim to strictly adhere to RFC 7234.
+     */
+    origin_cache_control?: boolean;
+
+    /**
+     * Whether to generate Cloudflare error pages for issues from the origin server.
+     */
+    origin_error_page_passthru?: boolean;
+
+    /**
+     * A timeout value between two successive read operations to use for your origin
+     * server. Historically, the timeout value between two read options from Cloudflare
+     * to an origin server is 100 seconds. If you are attempting to reduce HTTP 524
+     * errors because of timeouts from an origin server, try increasing this timeout
+     * value.
+     */
+    read_timeout?: number;
+
+    /**
+     * Whether Cloudflare should respect strong ETag (entity tag) headers. If false,
+     * Cloudflare converts strong ETag headers to weak ETag headers.
+     */
+    respect_strong_etags?: boolean;
+
+    /**
+     * When to serve stale content from cache.
+     */
+    serve_stale?: ActionParameters.ServeStale;
+  }
+
+  export namespace ActionParameters {
+    /**
+     * How long client browsers should cache the response. Cloudflare cache purge will
+     * not purge content cached on client browsers, so high browser TTLs may lead to
+     * stale content.
+     */
+    export interface BrowserTTL {
       /**
-       * URL pattern for the Use-As-Dictionary match field. This pattern specifies which
-       * URLs can use this response as a dictionary.
+       * The browser TTL mode.
        */
-      match_pattern: string;
+      mode: 'respect_origin' | 'bypass_by_default' | 'override_origin' | 'bypass';
+
+      /**
+       * The browser TTL (in seconds) if you choose the "override_origin" mode.
+       */
+      default?: number;
+    }
+
+    /**
+     * Which components of the request are included in or excluded from the cache key
+     * Cloudflare uses to store the response in cache.
+     */
+    export interface CacheKey {
+      /**
+       * Whether to separate cached content based on the visitor's device type.
+       */
+      cache_by_device_type?: boolean;
+
+      /**
+       * Whether to protect from web cache deception attacks, while allowing static
+       * assets to be cached.
+       */
+      cache_deception_armor?: boolean;
+
+      /**
+       * Which components of the request are included or excluded from the cache key.
+       */
+      custom_key?: CacheKey.CustomKey;
+
+      /**
+       * Whether to treat requests with the same query parameters the same, regardless of
+       * the order those query parameters are in.
+       */
+      ignore_query_strings_order?: boolean;
+    }
+
+    export namespace CacheKey {
+      /**
+       * Which components of the request are included or excluded from the cache key.
+       */
+      export interface CustomKey {
+        /**
+         * Which cookies to include in the cache key.
+         */
+        cookie?: CustomKey.Cookie;
+
+        /**
+         * Which headers to include in the cache key.
+         */
+        header?: CustomKey.Header;
+
+        /**
+         * How to use the host in the cache key.
+         */
+        host?: CustomKey.Host;
+
+        /**
+         * Which query string parameters to include in or exclude from the cache key.
+         */
+        query_string?: CustomKey.QueryString;
+
+        /**
+         * How to use characteristics of the request user agent in the cache key.
+         */
+        user?: CustomKey.User;
+      }
+
+      export namespace CustomKey {
+        /**
+         * Which cookies to include in the cache key.
+         */
+        export interface Cookie {
+          /**
+           * A list of cookies to check for the presence of. The presence of these cookies is
+           * included in the cache key.
+           */
+          check_presence?: Array<string>;
+
+          /**
+           * A list of cookies to include in the cache key.
+           */
+          include?: Array<string>;
+        }
+
+        /**
+         * Which headers to include in the cache key.
+         */
+        export interface Header {
+          /**
+           * A list of headers to check for the presence of. The presence of these headers is
+           * included in the cache key.
+           */
+          check_presence?: Array<string>;
+
+          /**
+           * A mapping of header names to a list of values. If a header is present in the
+           * request and contains any of the values provided, its value is included in the
+           * cache key.
+           */
+          contains?: { [key: string]: Array<string> };
+
+          /**
+           * Whether to exclude the origin header in the cache key.
+           */
+          exclude_origin?: boolean;
+
+          /**
+           * A list of headers to include in the cache key.
+           */
+          include?: Array<string>;
+        }
+
+        /**
+         * How to use the host in the cache key.
+         */
+        export interface Host {
+          /**
+           * Whether to use the resolved host in the cache key.
+           */
+          resolved?: boolean;
+        }
+
+        /**
+         * Which query string parameters to include in or exclude from the cache key.
+         */
+        export interface QueryString {
+          /**
+           * Which query string parameters to exclude from the cache key.
+           */
+          exclude?: QueryString.Exclude;
+
+          /**
+           * Which query string parameters to include in the cache key.
+           */
+          include?: QueryString.Include;
+        }
+
+        export namespace QueryString {
+          /**
+           * Which query string parameters to exclude from the cache key.
+           */
+          export interface Exclude {
+            /**
+             * Whether to exclude all query string parameters from the cache key.
+             */
+            all?: true;
+
+            /**
+             * A list of query string parameters to exclude from the cache key.
+             */
+            list?: Array<string>;
+          }
+
+          /**
+           * Which query string parameters to include in the cache key.
+           */
+          export interface Include {
+            /**
+             * Whether to include all query string parameters in the cache key.
+             */
+            all?: true;
+
+            /**
+             * A list of query string parameters to include in the cache key.
+             */
+            list?: Array<string>;
+          }
+        }
+
+        /**
+         * How to use characteristics of the request user agent in the cache key.
+         */
+        export interface User {
+          /**
+           * Whether to use the user agent's device type in the cache key.
+           */
+          device_type?: boolean;
+
+          /**
+           * Whether to use the user agents's country in the cache key.
+           */
+          geo?: boolean;
+
+          /**
+           * Whether to use the user agent's language in the cache key.
+           */
+          lang?: boolean;
+        }
+      }
+    }
+
+    /**
+     * Settings to determine whether the request's response from origin is eligible for
+     * Cache Reserve (requires a Cache Reserve add-on plan).
+     */
+    export interface CacheReserve {
+      /**
+       * Whether Cache Reserve is enabled. If this is true and a request meets
+       * eligibility criteria, Cloudflare will write the resource to Cache Reserve.
+       */
+      eligible: boolean;
+
+      /**
+       * The minimum file size eligible for storage in Cache Reserve.
+       */
+      minimum_file_size?: number;
+    }
+
+    /**
+     * How long the Cloudflare edge network should cache the response.
+     */
+    export interface EdgeTTL {
+      /**
+       * The edge TTL mode.
+       */
+      mode: 'respect_origin' | 'bypass_by_default' | 'override_origin';
+
+      /**
+       * The edge TTL (in seconds) if you choose the "override_origin" mode.
+       */
+      default?: number;
+
+      /**
+       * A list of TTLs to apply to specific status codes or status code ranges.
+       */
+      status_code_ttl?: Array<EdgeTTL.StatusCodeTTL>;
+    }
+
+    export namespace EdgeTTL {
+      export interface StatusCodeTTL {
+        /**
+         * The time to cache the response for (in seconds). A value of 0 is equivalent to
+         * setting the cache control header with the value "no-cache". A value of -1 is
+         * equivalent to setting the cache control header with the value of "no-store".
+         */
+        value: number;
+
+        /**
+         * A single status code to apply the TTL to.
+         */
+        status_code?: number;
+
+        /**
+         * A range of status codes to apply the TTL to.
+         */
+        status_code_range?: StatusCodeTTL.StatusCodeRange;
+      }
+
+      export namespace StatusCodeTTL {
+        /**
+         * A range of status codes to apply the TTL to.
+         */
+        export interface StatusCodeRange {
+          /**
+           * The lower bound of the range.
+           */
+          from?: number;
+
+          /**
+           * The upper bound of the range.
+           */
+          to?: number;
+        }
+      }
+    }
+
+    /**
+     * When to serve stale content from cache.
+     */
+    export interface ServeStale {
+      /**
+       * Whether Cloudflare should disable serving stale content while getting the latest
+       * content from the origin.
+       */
+      disable_stale_while_updating?: boolean;
     }
   }
 
@@ -3109,11 +5850,6 @@ export namespace SetConfigRule {
     bic?: boolean;
 
     /**
-     * Whether to enable content conversion (e.g., HTML to Markdown).
-     */
-    content_converter?: boolean;
-
-    /**
      * @deprecated Cloudflare Apps are deprected.
      */
     disable_apps?: true;
@@ -3165,10 +5901,252 @@ export namespace SetConfigRule {
     polish?: 'off' | 'lossless' | 'lossy' | 'webp';
 
     /**
-     * Whether to redirect verified AI training crawlers to canonical URLs found in the
-     * HTML response.
+     * The request body buffering mode.
      */
-    redirects_for_ai_training?: boolean;
+    request_body_buffering?: 'none' | 'standard' | 'full';
+
+    /**
+     * The response body buffering mode.
+     */
+    response_body_buffering?: 'none' | 'standard';
+
+    /**
+     * Whether to enable Rocket Loader.
+     */
+    rocket_loader?: boolean;
+
+    /**
+     * The Security Level to configure.
+     */
+    security_level?: 'off' | 'essentially_off' | 'low' | 'medium' | 'high' | 'under_attack';
+
+    /**
+     * Whether to enable Server-Side Excludes.
+     */
+    server_side_excludes?: boolean;
+
+    /**
+     * The SSL level to configure.
+     */
+    ssl?: 'off' | 'flexible' | 'full' | 'strict' | 'origin_pull';
+
+    /**
+     * Whether to enable Signed Exchanges (SXG).
+     */
+    sxg?: boolean;
+  }
+
+  export namespace ActionParameters {
+    /**
+     * Which file extensions to minify automatically.
+     */
+    export interface Autominify {
+      /**
+       * Whether to minify CSS files.
+       */
+      css?: boolean;
+
+      /**
+       * Whether to minify HTML files.
+       */
+      html?: boolean;
+
+      /**
+       * Whether to minify JavaScript files.
+       */
+      js?: boolean;
+    }
+  }
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  export interface ExposedCredentialCheck {
+    /**
+     * An expression that selects the password used in the credentials check.
+     */
+    password_expression: string;
+
+    /**
+     * An expression that selects the user ID used in the credentials check.
+     */
+    username_expression: string;
+  }
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  export interface Ratelimit {
+    /**
+     * Characteristics of the request on which the rate limit counter will be
+     * incremented.
+     */
+    characteristics: Array<string>;
+
+    /**
+     * Period in seconds over which the counter is being incremented.
+     */
+    period: number;
+
+    /**
+     * An expression that defines when the rate limit counter should be incremented. It
+     * defaults to the same as the rule's expression.
+     */
+    counting_expression?: string;
+
+    /**
+     * Period of time in seconds after which the action will be disabled following its
+     * first execution.
+     */
+    mitigation_timeout?: number;
+
+    /**
+     * The threshold of requests per period after which the action will be executed for
+     * the first time.
+     */
+    requests_per_period?: number;
+
+    /**
+     * Whether counting is only performed when an origin is reached.
+     */
+    requests_to_origin?: boolean;
+
+    /**
+     * The score threshold per period for which the action will be executed the first
+     * time.
+     */
+    score_per_period?: number;
+
+    /**
+     * A response header name provided by the origin, which contains the score to
+     * increment rate limit counter with.
+     */
+    score_response_header_name?: string;
+  }
+}
+
+export interface SetConfigRuleParam {
+  /**
+   * The unique ID of the rule.
+   */
+  id?: string;
+
+  /**
+   * The action to perform when the rule matches.
+   */
+  action?: 'set_config';
+
+  /**
+   * The parameters configuring the rule's action.
+   */
+  action_parameters?: SetConfigRuleParam.ActionParameters;
+
+  /**
+   * An informative description of the rule.
+   */
+  description?: string;
+
+  /**
+   * Whether the rule should be executed.
+   */
+  enabled?: boolean;
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  exposed_credential_check?: SetConfigRuleParam.ExposedCredentialCheck;
+
+  /**
+   * The expression defining which traffic will match the rule.
+   */
+  expression?: string;
+
+  /**
+   * An object configuring the rule's logging behavior.
+   */
+  logging?: LoggingParam;
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  ratelimit?: SetConfigRuleParam.Ratelimit;
+
+  /**
+   * The reference of the rule (the rule's ID by default).
+   */
+  ref?: string;
+}
+
+export namespace SetConfigRuleParam {
+  /**
+   * The parameters configuring the rule's action.
+   */
+  export interface ActionParameters {
+    /**
+     * Whether to enable Automatic HTTPS Rewrites.
+     */
+    automatic_https_rewrites?: boolean;
+
+    /**
+     * Which file extensions to minify automatically.
+     */
+    autominify?: ActionParameters.Autominify;
+
+    /**
+     * Whether to enable Browser Integrity Check (BIC).
+     */
+    bic?: boolean;
+
+    /**
+     * @deprecated Cloudflare Apps are deprected.
+     */
+    disable_apps?: true;
+
+    /**
+     * Whether to disable Pay Per Crawl.
+     */
+    disable_pay_per_crawl?: true;
+
+    /**
+     * Whether to disable Real User Monitoring (RUM).
+     */
+    disable_rum?: true;
+
+    /**
+     * Whether to disable Zaraz.
+     */
+    disable_zaraz?: true;
+
+    /**
+     * Whether to enable Email Obfuscation.
+     */
+    email_obfuscation?: boolean;
+
+    /**
+     * Whether to enable Cloudflare Fonts.
+     */
+    fonts?: boolean;
+
+    /**
+     * Whether to enable Hotlink Protection.
+     */
+    hotlink_protection?: boolean;
+
+    /**
+     * @deprecated Mirage is deprecated. More information at
+     * https://developers.cloudflare.com/speed/optimization/images/mirage/.
+     */
+    mirage?: boolean;
+
+    /**
+     * Whether to enable Opportunistic Encryption.
+     */
+    opportunistic_encryption?: boolean;
+
+    /**
+     * The Polish level to configure.
+     */
+    polish?: 'off' | 'lossless' | 'lossy' | 'webp';
 
     /**
      * The request body buffering mode.
@@ -3470,6 +6448,9568 @@ export namespace SkipRule {
   }
 }
 
+export interface SkipRuleParam {
+  /**
+   * The unique ID of the rule.
+   */
+  id?: string;
+
+  /**
+   * The action to perform when the rule matches.
+   */
+  action?: 'skip';
+
+  /**
+   * The parameters configuring the rule's action.
+   */
+  action_parameters?: SkipRuleParam.ActionParameters;
+
+  /**
+   * An informative description of the rule.
+   */
+  description?: string;
+
+  /**
+   * Whether the rule should be executed.
+   */
+  enabled?: boolean;
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  exposed_credential_check?: SkipRuleParam.ExposedCredentialCheck;
+
+  /**
+   * The expression defining which traffic will match the rule.
+   */
+  expression?: string;
+
+  /**
+   * An object configuring the rule's logging behavior.
+   */
+  logging?: LoggingParam;
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  ratelimit?: SkipRuleParam.Ratelimit;
+
+  /**
+   * The reference of the rule (the rule's ID by default).
+   */
+  ref?: string;
+}
+
+export namespace SkipRuleParam {
+  /**
+   * The parameters configuring the rule's action.
+   */
+  export interface ActionParameters {
+    /**
+     * A phase to skip the execution of. This option is only compatible with the
+     * products option.
+     */
+    phase?: 'current';
+
+    /**
+     * A list of phases to skip the execution of. This option is incompatible with the
+     * rulesets option.
+     */
+    phases?: Array<RulesetsAPI.PhaseParam>;
+
+    /**
+     * A list of legacy security products to skip the execution of.
+     */
+    products?: Array<'bic' | 'hot' | 'rateLimit' | 'securityLevel' | 'uaBlock' | 'waf' | 'zoneLockdown'>;
+
+    /**
+     * A mapping of ruleset IDs to a list of rule IDs in that ruleset to skip the
+     * execution of. This option is incompatible with the ruleset option.
+     */
+    rules?: { [key: string]: Array<string> };
+
+    /**
+     * A ruleset to skip the execution of. This option is incompatible with the
+     * rulesets option.
+     */
+    ruleset?: 'current';
+
+    /**
+     * A list of ruleset IDs to skip the execution of. This option is incompatible with
+     * the ruleset and phases options.
+     */
+    rulesets?: Array<string>;
+  }
+
+  /**
+   * Configuration for exposed credential checking.
+   */
+  export interface ExposedCredentialCheck {
+    /**
+     * An expression that selects the password used in the credentials check.
+     */
+    password_expression: string;
+
+    /**
+     * An expression that selects the user ID used in the credentials check.
+     */
+    username_expression: string;
+  }
+
+  /**
+   * An object configuring the rule's rate limit behavior.
+   */
+  export interface Ratelimit {
+    /**
+     * Characteristics of the request on which the rate limit counter will be
+     * incremented.
+     */
+    characteristics: Array<string>;
+
+    /**
+     * Period in seconds over which the counter is being incremented.
+     */
+    period: number;
+
+    /**
+     * An expression that defines when the rate limit counter should be incremented. It
+     * defaults to the same as the rule's expression.
+     */
+    counting_expression?: string;
+
+    /**
+     * Period of time in seconds after which the action will be disabled following its
+     * first execution.
+     */
+    mitigation_timeout?: number;
+
+    /**
+     * The threshold of requests per period after which the action will be executed for
+     * the first time.
+     */
+    requests_per_period?: number;
+
+    /**
+     * Whether counting is only performed when an origin is reached.
+     */
+    requests_to_origin?: boolean;
+
+    /**
+     * The score threshold per period for which the action will be executed the first
+     * time.
+     */
+    score_per_period?: number;
+
+    /**
+     * A response header name provided by the origin, which contains the score to
+     * increment rate limit counter with.
+     */
+    score_response_header_name?: string;
+  }
+}
+
+/**
+ * A ruleset object.
+ */
+export interface RuleCreateResponse {
+  /**
+   * The unique ID of the ruleset.
+   */
+  id: string;
+
+  /**
+   * The kind of the ruleset.
+   */
+  kind: RulesetsAPI.Kind;
+
+  /**
+   * The timestamp of when the ruleset was last modified.
+   */
+  last_updated: string;
+
+  /**
+   * The human-readable name of the ruleset.
+   */
+  name: string;
+
+  /**
+   * The phase of the ruleset.
+   */
+  phase: RulesetsAPI.Phase;
+
+  /**
+   * The list of rules in the ruleset.
+   */
+  rules: Array<
+    | BlockRule
+    | RuleCreateResponse.RulesetsChallengeRule
+    | CompressResponseRule
+    | DDoSDynamicRule
+    | ExecuteRule
+    | ForceConnectionCloseRule
+    | RuleCreateResponse.RulesetsJSChallengeRule
+    | LogRule
+    | LogCustomFieldRule
+    | ManagedChallengeRule
+    | RedirectRule
+    | RewriteRule
+    | RouteRule
+    | ScoreRule
+    | ServeErrorRule
+    | SetCacheSettingsRule
+    | SetConfigRule
+    | SkipRule
+  >;
+
+  /**
+   * The version of the ruleset.
+   */
+  version: string;
+
+  /**
+   * An informative description of the ruleset.
+   */
+  description?: string;
+}
+
+export namespace RuleCreateResponse {
+  export interface RulesetsChallengeRule {
+    /**
+     * The timestamp of when the rule was last modified.
+     */
+    last_updated: string;
+
+    /**
+     * The version of the rule.
+     */
+    version: string;
+
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * The categories of the rule.
+     */
+    categories?: Array<string>;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.Logging;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface RulesetsJSChallengeRule {
+    /**
+     * The timestamp of when the rule was last modified.
+     */
+    last_updated: string;
+
+    /**
+     * The version of the rule.
+     */
+    version: string;
+
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'js_challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * The categories of the rule.
+     */
+    categories?: Array<string>;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsJSChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.Logging;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsJSChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsJSChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+}
+
+/**
+ * A ruleset object.
+ */
+export interface RuleDeleteResponse {
+  /**
+   * The unique ID of the ruleset.
+   */
+  id: string;
+
+  /**
+   * The kind of the ruleset.
+   */
+  kind: RulesetsAPI.Kind;
+
+  /**
+   * The timestamp of when the ruleset was last modified.
+   */
+  last_updated: string;
+
+  /**
+   * The human-readable name of the ruleset.
+   */
+  name: string;
+
+  /**
+   * The phase of the ruleset.
+   */
+  phase: RulesetsAPI.Phase;
+
+  /**
+   * The list of rules in the ruleset.
+   */
+  rules: Array<
+    | BlockRule
+    | RuleDeleteResponse.RulesetsChallengeRule
+    | CompressResponseRule
+    | DDoSDynamicRule
+    | ExecuteRule
+    | ForceConnectionCloseRule
+    | RuleDeleteResponse.RulesetsJSChallengeRule
+    | LogRule
+    | LogCustomFieldRule
+    | ManagedChallengeRule
+    | RedirectRule
+    | RewriteRule
+    | RouteRule
+    | ScoreRule
+    | ServeErrorRule
+    | SetCacheSettingsRule
+    | SetConfigRule
+    | SkipRule
+  >;
+
+  /**
+   * The version of the ruleset.
+   */
+  version: string;
+
+  /**
+   * An informative description of the ruleset.
+   */
+  description?: string;
+}
+
+export namespace RuleDeleteResponse {
+  export interface RulesetsChallengeRule {
+    /**
+     * The timestamp of when the rule was last modified.
+     */
+    last_updated: string;
+
+    /**
+     * The version of the rule.
+     */
+    version: string;
+
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * The categories of the rule.
+     */
+    categories?: Array<string>;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.Logging;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface RulesetsJSChallengeRule {
+    /**
+     * The timestamp of when the rule was last modified.
+     */
+    last_updated: string;
+
+    /**
+     * The version of the rule.
+     */
+    version: string;
+
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'js_challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * The categories of the rule.
+     */
+    categories?: Array<string>;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsJSChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.Logging;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsJSChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsJSChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+}
+
+/**
+ * A ruleset object.
+ */
+export interface RuleEditResponse {
+  /**
+   * The unique ID of the ruleset.
+   */
+  id: string;
+
+  /**
+   * The kind of the ruleset.
+   */
+  kind: RulesetsAPI.Kind;
+
+  /**
+   * The timestamp of when the ruleset was last modified.
+   */
+  last_updated: string;
+
+  /**
+   * The human-readable name of the ruleset.
+   */
+  name: string;
+
+  /**
+   * The phase of the ruleset.
+   */
+  phase: RulesetsAPI.Phase;
+
+  /**
+   * The list of rules in the ruleset.
+   */
+  rules: Array<
+    | BlockRule
+    | RuleEditResponse.RulesetsChallengeRule
+    | CompressResponseRule
+    | DDoSDynamicRule
+    | ExecuteRule
+    | ForceConnectionCloseRule
+    | RuleEditResponse.RulesetsJSChallengeRule
+    | LogRule
+    | LogCustomFieldRule
+    | ManagedChallengeRule
+    | RedirectRule
+    | RewriteRule
+    | RouteRule
+    | ScoreRule
+    | ServeErrorRule
+    | SetCacheSettingsRule
+    | SetConfigRule
+    | SkipRule
+  >;
+
+  /**
+   * The version of the ruleset.
+   */
+  version: string;
+
+  /**
+   * An informative description of the ruleset.
+   */
+  description?: string;
+}
+
+export namespace RuleEditResponse {
+  export interface RulesetsChallengeRule {
+    /**
+     * The timestamp of when the rule was last modified.
+     */
+    last_updated: string;
+
+    /**
+     * The version of the rule.
+     */
+    version: string;
+
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * The categories of the rule.
+     */
+    categories?: Array<string>;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.Logging;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface RulesetsJSChallengeRule {
+    /**
+     * The timestamp of when the rule was last modified.
+     */
+    last_updated: string;
+
+    /**
+     * The version of the rule.
+     */
+    version: string;
+
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'js_challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * The categories of the rule.
+     */
+    categories?: Array<string>;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsJSChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.Logging;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsJSChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsJSChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+}
+
+export type RuleCreateParams =
+  | RuleCreateParams.BlockRule
+  | RuleCreateParams.ChallengeRule
+  | RuleCreateParams.ResponseCompressionRule
+  | RuleCreateParams.DDoSDynamicRule
+  | RuleCreateParams.ExecuteRule
+  | RuleCreateParams.ForceConnectionCloseRule
+  | RuleCreateParams.JavaScriptChallengeRule
+  | RuleCreateParams.LogRule
+  | RuleCreateParams.LogCustomFieldRule
+  | RuleCreateParams.ManagedChallengeRule
+  | RuleCreateParams.RedirectRule
+  | RuleCreateParams.RewriteRule
+  | RuleCreateParams.RouteRule
+  | RuleCreateParams.ScoreRule
+  | RuleCreateParams.ServeErrorRule
+  | RuleCreateParams.SetCacheSettingsRule
+  | RuleCreateParams.SetConfigurationRule
+  | RuleCreateParams.SkipRule;
+
+export declare namespace RuleCreateParams {
+  export interface BlockRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'block';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: BlockRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: BlockRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: BlockRule.BeforePosition | BlockRule.AfterPosition | BlockRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: BlockRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace BlockRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * The response to show when the block is applied.
+       */
+      response?: ActionParameters.Response;
+    }
+
+    export namespace ActionParameters {
+      /**
+       * The response to show when the block is applied.
+       */
+      export interface Response {
+        /**
+         * The content to return.
+         */
+        content: string;
+
+        /**
+         * The type of the content to return.
+         */
+        content_type: string;
+
+        /**
+         * The status code to return.
+         */
+        status_code: number;
+      }
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface ChallengeRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'challenge';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: ChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: ChallengeRule.BeforePosition | ChallengeRule.AfterPosition | ChallengeRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: ChallengeRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace ChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface ResponseCompressionRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'compress_response';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: ResponseCompressionRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: ResponseCompressionRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?:
+      | ResponseCompressionRule.BeforePosition
+      | ResponseCompressionRule.AfterPosition
+      | ResponseCompressionRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: ResponseCompressionRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace ResponseCompressionRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * Custom order for compression algorithms.
+       */
+      algorithms: Array<ActionParameters.Algorithm>;
+    }
+
+    export namespace ActionParameters {
+      /**
+       * Compression algorithm to enable.
+       */
+      export interface Algorithm {
+        /**
+         * Name of the compression algorithm to enable.
+         */
+        name?: 'none' | 'auto' | 'default' | 'gzip' | 'brotli' | 'zstd';
+      }
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface DDoSDynamicRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'ddos_dynamic';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: DDoSDynamicRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: DDoSDynamicRule.BeforePosition | DDoSDynamicRule.AfterPosition | DDoSDynamicRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: DDoSDynamicRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace DDoSDynamicRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface ExecuteRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'execute';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: ExecuteRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: ExecuteRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: ExecuteRule.BeforePosition | ExecuteRule.AfterPosition | ExecuteRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: ExecuteRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace ExecuteRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * The ID of the ruleset to execute.
+       */
+      id: string;
+
+      /**
+       * The configuration to use for matched data logging.
+       */
+      matched_data?: ActionParameters.MatchedData;
+
+      /**
+       * A set of overrides to apply to the target ruleset.
+       */
+      overrides?: ActionParameters.Overrides;
+    }
+
+    export namespace ActionParameters {
+      /**
+       * The configuration to use for matched data logging.
+       */
+      export interface MatchedData {
+        /**
+         * The public key to encrypt matched data logs with.
+         */
+        public_key: string;
+      }
+
+      /**
+       * A set of overrides to apply to the target ruleset.
+       */
+      export interface Overrides {
+        /**
+         * An action to override all rules with. This option has lower precedence than rule
+         * and category overrides.
+         */
+        action?: string;
+
+        /**
+         * A list of category-level overrides. This option has the second-highest
+         * precedence after rule-level overrides.
+         */
+        categories?: Array<Overrides.Category>;
+
+        /**
+         * Whether to enable execution of all rules. This option has lower precedence than
+         * rule and category overrides.
+         */
+        enabled?: boolean;
+
+        /**
+         * A list of rule-level overrides. This option has the highest precedence.
+         */
+        rules?: Array<Overrides.Rule>;
+
+        /**
+         * A sensitivity level to set for all rules. This option has lower precedence than
+         * rule and category overrides and is only applicable for DDoS phases.
+         */
+        sensitivity_level?: 'default' | 'medium' | 'low' | 'eoff';
+      }
+
+      export namespace Overrides {
+        /**
+         * A category-level override.
+         */
+        export interface Category {
+          /**
+           * The name of the category to override.
+           */
+          category: string;
+
+          /**
+           * The action to override rules in the category with.
+           */
+          action?: string;
+
+          /**
+           * Whether to enable execution of rules in the category.
+           */
+          enabled?: boolean;
+
+          /**
+           * The sensitivity level to use for rules in the category. This option is only
+           * applicable for DDoS phases.
+           */
+          sensitivity_level?: 'default' | 'medium' | 'low' | 'eoff';
+        }
+
+        /**
+         * A rule-level override.
+         */
+        export interface Rule {
+          /**
+           * The ID of the rule to override.
+           */
+          id: string;
+
+          /**
+           * The action to override the rule with.
+           */
+          action?: string;
+
+          /**
+           * Whether to enable execution of the rule.
+           */
+          enabled?: boolean;
+
+          /**
+           * The score threshold to use for the rule.
+           */
+          score_threshold?: number;
+
+          /**
+           * The sensitivity level to use for the rule. This option is only applicable for
+           * DDoS phases.
+           */
+          sensitivity_level?: 'default' | 'medium' | 'low' | 'eoff';
+        }
+      }
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface ForceConnectionCloseRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'force_connection_close';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: ForceConnectionCloseRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?:
+      | ForceConnectionCloseRule.BeforePosition
+      | ForceConnectionCloseRule.AfterPosition
+      | ForceConnectionCloseRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: ForceConnectionCloseRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace ForceConnectionCloseRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface JavaScriptChallengeRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'js_challenge';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: JavaScriptChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?:
+      | JavaScriptChallengeRule.BeforePosition
+      | JavaScriptChallengeRule.AfterPosition
+      | JavaScriptChallengeRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: JavaScriptChallengeRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace JavaScriptChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface LogRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'log';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: LogRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: LogRule.BeforePosition | LogRule.AfterPosition | LogRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: LogRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace LogRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface LogCustomFieldRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'log_custom_field';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: LogCustomFieldRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: LogCustomFieldRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?:
+      | LogCustomFieldRule.BeforePosition
+      | LogCustomFieldRule.AfterPosition
+      | LogCustomFieldRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: LogCustomFieldRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace LogCustomFieldRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * The cookie fields to log.
+       */
+      cookie_fields?: Array<ActionParameters.CookieField>;
+
+      /**
+       * The raw response fields to log.
+       */
+      raw_response_fields?: Array<ActionParameters.RawResponseField>;
+
+      /**
+       * The raw request fields to log.
+       */
+      request_fields?: Array<ActionParameters.RequestField>;
+
+      /**
+       * The transformed response fields to log.
+       */
+      response_fields?: Array<ActionParameters.ResponseField>;
+
+      /**
+       * The transformed request fields to log.
+       */
+      transformed_request_fields?: Array<ActionParameters.TransformedRequestField>;
+    }
+
+    export namespace ActionParameters {
+      /**
+       * The cookie field to log.
+       */
+      export interface CookieField {
+        /**
+         * The name of the cookie.
+         */
+        name: string;
+      }
+
+      /**
+       * The raw response field to log.
+       */
+      export interface RawResponseField {
+        /**
+         * The name of the response header.
+         */
+        name: string;
+
+        /**
+         * Whether to log duplicate values of the same header.
+         */
+        preserve_duplicates?: boolean;
+      }
+
+      /**
+       * The raw request field to log.
+       */
+      export interface RequestField {
+        /**
+         * The name of the header.
+         */
+        name: string;
+      }
+
+      /**
+       * The transformed response field to log.
+       */
+      export interface ResponseField {
+        /**
+         * The name of the response header.
+         */
+        name: string;
+
+        /**
+         * Whether to log duplicate values of the same header.
+         */
+        preserve_duplicates?: boolean;
+      }
+
+      /**
+       * The transformed request field to log.
+       */
+      export interface TransformedRequestField {
+        /**
+         * The name of the header.
+         */
+        name: string;
+      }
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface ManagedChallengeRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'managed_challenge';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: ManagedChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?:
+      | ManagedChallengeRule.BeforePosition
+      | ManagedChallengeRule.AfterPosition
+      | ManagedChallengeRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: ManagedChallengeRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace ManagedChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface RedirectRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'redirect';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: RedirectRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RedirectRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: RedirectRule.BeforePosition | RedirectRule.AfterPosition | RedirectRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RedirectRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RedirectRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * A redirect based on a bulk list lookup.
+       */
+      from_list?: ActionParameters.FromList;
+
+      /**
+       * A redirect based on the request properties.
+       */
+      from_value?: ActionParameters.FromValue;
+    }
+
+    export namespace ActionParameters {
+      /**
+       * A redirect based on a bulk list lookup.
+       */
+      export interface FromList {
+        /**
+         * An expression that evaluates to the list lookup key.
+         */
+        key: string;
+
+        /**
+         * The name of the list to match against.
+         */
+        name: string;
+      }
+
+      /**
+       * A redirect based on the request properties.
+       */
+      export interface FromValue {
+        /**
+         * A URL to redirect the request to.
+         */
+        target_url: FromValue.TargetURL;
+
+        /**
+         * Whether to keep the query string of the original request.
+         */
+        preserve_query_string?: boolean;
+
+        /**
+         * The status code to use for the redirect.
+         */
+        status_code?: 301 | 302 | 303 | 307 | 308;
+      }
+
+      export namespace FromValue {
+        /**
+         * A URL to redirect the request to.
+         */
+        export interface TargetURL {
+          /**
+           * An expression that evaluates to a URL to redirect the request to.
+           */
+          expression?: string;
+
+          /**
+           * A URL to redirect the request to.
+           */
+          value?: string;
+        }
+      }
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface RewriteRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'rewrite';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: RewriteRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RewriteRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: RewriteRule.BeforePosition | RewriteRule.AfterPosition | RewriteRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RewriteRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RewriteRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * A map of headers to rewrite.
+       */
+      headers?: {
+        [key: string]:
+          | ActionParameters.AddStaticHeader
+          | ActionParameters.AddDynamicHeader
+          | ActionParameters.SetStaticHeader
+          | ActionParameters.SetDynamicHeader
+          | ActionParameters.RemoveHeader;
+      };
+
+      /**
+       * A URI path rewrite.
+       */
+      uri?: ActionParameters.URIPath | ActionParameters.URIQuery;
+    }
+
+    export namespace ActionParameters {
+      /**
+       * A header with a static value to add.
+       */
+      export interface AddStaticHeader {
+        /**
+         * The operation to perform on the header.
+         */
+        operation: 'add';
+
+        /**
+         * A static value for the header.
+         */
+        value: string;
+      }
+
+      /**
+       * A header with a dynamic value to add.
+       */
+      export interface AddDynamicHeader {
+        /**
+         * An expression that evaluates to a value for the header.
+         */
+        expression: string;
+
+        /**
+         * The operation to perform on the header.
+         */
+        operation: 'add';
+      }
+
+      /**
+       * A header with a static value to set.
+       */
+      export interface SetStaticHeader {
+        /**
+         * The operation to perform on the header.
+         */
+        operation: 'set';
+
+        /**
+         * A static value for the header.
+         */
+        value: string;
+      }
+
+      /**
+       * A header with a dynamic value to set.
+       */
+      export interface SetDynamicHeader {
+        /**
+         * An expression that evaluates to a value for the header.
+         */
+        expression: string;
+
+        /**
+         * The operation to perform on the header.
+         */
+        operation: 'set';
+      }
+
+      /**
+       * A header to remove.
+       */
+      export interface RemoveHeader {
+        /**
+         * The operation to perform on the header.
+         */
+        operation: 'remove';
+      }
+
+      /**
+       * A URI path rewrite.
+       */
+      export interface URIPath {
+        /**
+         * A URI path rewrite.
+         */
+        path: URIPath.Path;
+      }
+
+      export namespace URIPath {
+        /**
+         * A URI path rewrite.
+         */
+        export interface Path {
+          /**
+           * An expression that evaluates to a value to rewrite the URI path to.
+           */
+          expression?: string;
+
+          /**
+           * A value to rewrite the URI path to.
+           */
+          value?: string;
+        }
+      }
+
+      /**
+       * A URI query rewrite.
+       */
+      export interface URIQuery {
+        /**
+         * A URI query rewrite.
+         */
+        query: URIQuery.Query;
+      }
+
+      export namespace URIQuery {
+        /**
+         * A URI query rewrite.
+         */
+        export interface Query {
+          /**
+           * An expression that evaluates to a value to rewrite the URI query to.
+           */
+          expression?: string;
+
+          /**
+           * A value to rewrite the URI query to.
+           */
+          value?: string;
+        }
+      }
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface RouteRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'route';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: RouteRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RouteRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: RouteRule.BeforePosition | RouteRule.AfterPosition | RouteRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RouteRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RouteRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * A value to rewrite the HTTP host header to.
+       */
+      host_header?: string;
+
+      /**
+       * An origin to route to.
+       */
+      origin?: ActionParameters.Origin;
+
+      /**
+       * A Server Name Indication (SNI) override.
+       */
+      sni?: ActionParameters.SNI;
+    }
+
+    export namespace ActionParameters {
+      /**
+       * An origin to route to.
+       */
+      export interface Origin {
+        /**
+         * A resolved host to route to.
+         */
+        host?: string;
+
+        /**
+         * A destination port to route to.
+         */
+        port?: number;
+      }
+
+      /**
+       * A Server Name Indication (SNI) override.
+       */
+      export interface SNI {
+        /**
+         * A value to override the SNI to.
+         */
+        value: string;
+      }
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface ScoreRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'score';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: ScoreRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: ScoreRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: ScoreRule.BeforePosition | ScoreRule.AfterPosition | ScoreRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: ScoreRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace ScoreRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * A delta to change the score by, which can be either positive or negative.
+       */
+      increment: number;
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface ServeErrorRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'serve_error';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: ServeErrorRule.ActionParametersContent | ServeErrorRule.ActionParametersAsset;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: ServeErrorRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: ServeErrorRule.BeforePosition | ServeErrorRule.AfterPosition | ServeErrorRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: ServeErrorRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace ServeErrorRule {
+    export interface ActionParametersContent {
+      /**
+       * The response content.
+       */
+      content: string;
+
+      /**
+       * The content type header to set with the error response.
+       */
+      content_type?: 'application/json' | 'text/html' | 'text/plain' | 'text/xml';
+
+      /**
+       * The status code to use for the error.
+       */
+      status_code?: number;
+    }
+
+    export interface ActionParametersAsset {
+      /**
+       * The name of a custom asset to serve as the error response.
+       */
+      asset_name: string;
+
+      /**
+       * The content type header to set with the error response.
+       */
+      content_type?: 'application/json' | 'text/html' | 'text/plain' | 'text/xml';
+
+      /**
+       * The status code to use for the error.
+       */
+      status_code?: number;
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface SetCacheSettingsRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'set_cache_settings';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: SetCacheSettingsRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: SetCacheSettingsRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?:
+      | SetCacheSettingsRule.BeforePosition
+      | SetCacheSettingsRule.AfterPosition
+      | SetCacheSettingsRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: SetCacheSettingsRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace SetCacheSettingsRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * A list of additional ports that caching should be enabled on.
+       */
+      additional_cacheable_ports?: Array<number>;
+
+      /**
+       * How long client browsers should cache the response. Cloudflare cache purge will
+       * not purge content cached on client browsers, so high browser TTLs may lead to
+       * stale content.
+       */
+      browser_ttl?: ActionParameters.BrowserTTL;
+
+      /**
+       * Whether the request's response from the origin is eligible for caching. Caching
+       * itself will still depend on the cache control header and your other caching
+       * configurations.
+       */
+      cache?: boolean;
+
+      /**
+       * Which components of the request are included in or excluded from the cache key
+       * Cloudflare uses to store the response in cache.
+       */
+      cache_key?: ActionParameters.CacheKey;
+
+      /**
+       * Settings to determine whether the request's response from origin is eligible for
+       * Cache Reserve (requires a Cache Reserve add-on plan).
+       */
+      cache_reserve?: ActionParameters.CacheReserve;
+
+      /**
+       * How long the Cloudflare edge network should cache the response.
+       */
+      edge_ttl?: ActionParameters.EdgeTTL;
+
+      /**
+       * Whether Cloudflare will aim to strictly adhere to RFC 7234.
+       */
+      origin_cache_control?: boolean;
+
+      /**
+       * Whether to generate Cloudflare error pages for issues from the origin server.
+       */
+      origin_error_page_passthru?: boolean;
+
+      /**
+       * A timeout value between two successive read operations to use for your origin
+       * server. Historically, the timeout value between two read options from Cloudflare
+       * to an origin server is 100 seconds. If you are attempting to reduce HTTP 524
+       * errors because of timeouts from an origin server, try increasing this timeout
+       * value.
+       */
+      read_timeout?: number;
+
+      /**
+       * Whether Cloudflare should respect strong ETag (entity tag) headers. If false,
+       * Cloudflare converts strong ETag headers to weak ETag headers.
+       */
+      respect_strong_etags?: boolean;
+
+      /**
+       * When to serve stale content from cache.
+       */
+      serve_stale?: ActionParameters.ServeStale;
+    }
+
+    export namespace ActionParameters {
+      /**
+       * How long client browsers should cache the response. Cloudflare cache purge will
+       * not purge content cached on client browsers, so high browser TTLs may lead to
+       * stale content.
+       */
+      export interface BrowserTTL {
+        /**
+         * The browser TTL mode.
+         */
+        mode: 'respect_origin' | 'bypass_by_default' | 'override_origin' | 'bypass';
+
+        /**
+         * The browser TTL (in seconds) if you choose the "override_origin" mode.
+         */
+        default?: number;
+      }
+
+      /**
+       * Which components of the request are included in or excluded from the cache key
+       * Cloudflare uses to store the response in cache.
+       */
+      export interface CacheKey {
+        /**
+         * Whether to separate cached content based on the visitor's device type.
+         */
+        cache_by_device_type?: boolean;
+
+        /**
+         * Whether to protect from web cache deception attacks, while allowing static
+         * assets to be cached.
+         */
+        cache_deception_armor?: boolean;
+
+        /**
+         * Which components of the request are included or excluded from the cache key.
+         */
+        custom_key?: CacheKey.CustomKey;
+
+        /**
+         * Whether to treat requests with the same query parameters the same, regardless of
+         * the order those query parameters are in.
+         */
+        ignore_query_strings_order?: boolean;
+      }
+
+      export namespace CacheKey {
+        /**
+         * Which components of the request are included or excluded from the cache key.
+         */
+        export interface CustomKey {
+          /**
+           * Which cookies to include in the cache key.
+           */
+          cookie?: CustomKey.Cookie;
+
+          /**
+           * Which headers to include in the cache key.
+           */
+          header?: CustomKey.Header;
+
+          /**
+           * How to use the host in the cache key.
+           */
+          host?: CustomKey.Host;
+
+          /**
+           * Which query string parameters to include in or exclude from the cache key.
+           */
+          query_string?: CustomKey.QueryString;
+
+          /**
+           * How to use characteristics of the request user agent in the cache key.
+           */
+          user?: CustomKey.User;
+        }
+
+        export namespace CustomKey {
+          /**
+           * Which cookies to include in the cache key.
+           */
+          export interface Cookie {
+            /**
+             * A list of cookies to check for the presence of. The presence of these cookies is
+             * included in the cache key.
+             */
+            check_presence?: Array<string>;
+
+            /**
+             * A list of cookies to include in the cache key.
+             */
+            include?: Array<string>;
+          }
+
+          /**
+           * Which headers to include in the cache key.
+           */
+          export interface Header {
+            /**
+             * A list of headers to check for the presence of. The presence of these headers is
+             * included in the cache key.
+             */
+            check_presence?: Array<string>;
+
+            /**
+             * A mapping of header names to a list of values. If a header is present in the
+             * request and contains any of the values provided, its value is included in the
+             * cache key.
+             */
+            contains?: { [key: string]: Array<string> };
+
+            /**
+             * Whether to exclude the origin header in the cache key.
+             */
+            exclude_origin?: boolean;
+
+            /**
+             * A list of headers to include in the cache key.
+             */
+            include?: Array<string>;
+          }
+
+          /**
+           * How to use the host in the cache key.
+           */
+          export interface Host {
+            /**
+             * Whether to use the resolved host in the cache key.
+             */
+            resolved?: boolean;
+          }
+
+          /**
+           * Which query string parameters to include in or exclude from the cache key.
+           */
+          export interface QueryString {
+            /**
+             * Which query string parameters to exclude from the cache key.
+             */
+            exclude?: QueryString.Exclude;
+
+            /**
+             * Which query string parameters to include in the cache key.
+             */
+            include?: QueryString.Include;
+          }
+
+          export namespace QueryString {
+            /**
+             * Which query string parameters to exclude from the cache key.
+             */
+            export interface Exclude {
+              /**
+               * Whether to exclude all query string parameters from the cache key.
+               */
+              all?: true;
+
+              /**
+               * A list of query string parameters to exclude from the cache key.
+               */
+              list?: Array<string>;
+            }
+
+            /**
+             * Which query string parameters to include in the cache key.
+             */
+            export interface Include {
+              /**
+               * Whether to include all query string parameters in the cache key.
+               */
+              all?: true;
+
+              /**
+               * A list of query string parameters to include in the cache key.
+               */
+              list?: Array<string>;
+            }
+          }
+
+          /**
+           * How to use characteristics of the request user agent in the cache key.
+           */
+          export interface User {
+            /**
+             * Whether to use the user agent's device type in the cache key.
+             */
+            device_type?: boolean;
+
+            /**
+             * Whether to use the user agents's country in the cache key.
+             */
+            geo?: boolean;
+
+            /**
+             * Whether to use the user agent's language in the cache key.
+             */
+            lang?: boolean;
+          }
+        }
+      }
+
+      /**
+       * Settings to determine whether the request's response from origin is eligible for
+       * Cache Reserve (requires a Cache Reserve add-on plan).
+       */
+      export interface CacheReserve {
+        /**
+         * Whether Cache Reserve is enabled. If this is true and a request meets
+         * eligibility criteria, Cloudflare will write the resource to Cache Reserve.
+         */
+        eligible: boolean;
+
+        /**
+         * The minimum file size eligible for storage in Cache Reserve.
+         */
+        minimum_file_size?: number;
+      }
+
+      /**
+       * How long the Cloudflare edge network should cache the response.
+       */
+      export interface EdgeTTL {
+        /**
+         * The edge TTL mode.
+         */
+        mode: 'respect_origin' | 'bypass_by_default' | 'override_origin';
+
+        /**
+         * The edge TTL (in seconds) if you choose the "override_origin" mode.
+         */
+        default?: number;
+
+        /**
+         * A list of TTLs to apply to specific status codes or status code ranges.
+         */
+        status_code_ttl?: Array<EdgeTTL.StatusCodeTTL>;
+      }
+
+      export namespace EdgeTTL {
+        export interface StatusCodeTTL {
+          /**
+           * The time to cache the response for (in seconds). A value of 0 is equivalent to
+           * setting the cache control header with the value "no-cache". A value of -1 is
+           * equivalent to setting the cache control header with the value of "no-store".
+           */
+          value: number;
+
+          /**
+           * A single status code to apply the TTL to.
+           */
+          status_code?: number;
+
+          /**
+           * A range of status codes to apply the TTL to.
+           */
+          status_code_range?: StatusCodeTTL.StatusCodeRange;
+        }
+
+        export namespace StatusCodeTTL {
+          /**
+           * A range of status codes to apply the TTL to.
+           */
+          export interface StatusCodeRange {
+            /**
+             * The lower bound of the range.
+             */
+            from?: number;
+
+            /**
+             * The upper bound of the range.
+             */
+            to?: number;
+          }
+        }
+      }
+
+      /**
+       * When to serve stale content from cache.
+       */
+      export interface ServeStale {
+        /**
+         * Whether Cloudflare should disable serving stale content while getting the latest
+         * content from the origin.
+         */
+        disable_stale_while_updating?: boolean;
+      }
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface SetConfigurationRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'set_config';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: SetConfigurationRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: SetConfigurationRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?:
+      | SetConfigurationRule.BeforePosition
+      | SetConfigurationRule.AfterPosition
+      | SetConfigurationRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: SetConfigurationRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace SetConfigurationRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * Whether to enable Automatic HTTPS Rewrites.
+       */
+      automatic_https_rewrites?: boolean;
+
+      /**
+       * Which file extensions to minify automatically.
+       */
+      autominify?: ActionParameters.Autominify;
+
+      /**
+       * Whether to enable Browser Integrity Check (BIC).
+       */
+      bic?: boolean;
+
+      /**
+       * @deprecated Cloudflare Apps are deprected.
+       */
+      disable_apps?: true;
+
+      /**
+       * Whether to disable Pay Per Crawl.
+       */
+      disable_pay_per_crawl?: true;
+
+      /**
+       * Whether to disable Real User Monitoring (RUM).
+       */
+      disable_rum?: true;
+
+      /**
+       * Whether to disable Zaraz.
+       */
+      disable_zaraz?: true;
+
+      /**
+       * Whether to enable Email Obfuscation.
+       */
+      email_obfuscation?: boolean;
+
+      /**
+       * Whether to enable Cloudflare Fonts.
+       */
+      fonts?: boolean;
+
+      /**
+       * Whether to enable Hotlink Protection.
+       */
+      hotlink_protection?: boolean;
+
+      /**
+       * @deprecated Mirage is deprecated. More information at
+       * https://developers.cloudflare.com/speed/optimization/images/mirage/.
+       */
+      mirage?: boolean;
+
+      /**
+       * Whether to enable Opportunistic Encryption.
+       */
+      opportunistic_encryption?: boolean;
+
+      /**
+       * The Polish level to configure.
+       */
+      polish?: 'off' | 'lossless' | 'lossy' | 'webp';
+
+      /**
+       * The request body buffering mode.
+       */
+      request_body_buffering?: 'none' | 'standard' | 'full';
+
+      /**
+       * The response body buffering mode.
+       */
+      response_body_buffering?: 'none' | 'standard';
+
+      /**
+       * Whether to enable Rocket Loader.
+       */
+      rocket_loader?: boolean;
+
+      /**
+       * The Security Level to configure.
+       */
+      security_level?: 'off' | 'essentially_off' | 'low' | 'medium' | 'high' | 'under_attack';
+
+      /**
+       * Whether to enable Server-Side Excludes.
+       */
+      server_side_excludes?: boolean;
+
+      /**
+       * The SSL level to configure.
+       */
+      ssl?: 'off' | 'flexible' | 'full' | 'strict' | 'origin_pull';
+
+      /**
+       * Whether to enable Signed Exchanges (SXG).
+       */
+      sxg?: boolean;
+    }
+
+    export namespace ActionParameters {
+      /**
+       * Which file extensions to minify automatically.
+       */
+      export interface Autominify {
+        /**
+         * Whether to minify CSS files.
+         */
+        css?: boolean;
+
+        /**
+         * Whether to minify HTML files.
+         */
+        html?: boolean;
+
+        /**
+         * Whether to minify JavaScript files.
+         */
+        js?: boolean;
+      }
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface SkipRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'skip';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: SkipRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: SkipRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: SkipRule.BeforePosition | SkipRule.AfterPosition | SkipRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: SkipRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace SkipRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * A phase to skip the execution of. This option is only compatible with the
+       * products option.
+       */
+      phase?: 'current';
+
+      /**
+       * A list of phases to skip the execution of. This option is incompatible with the
+       * rulesets option.
+       */
+      phases?: Array<RulesetsAPI.PhaseParam>;
+
+      /**
+       * A list of legacy security products to skip the execution of.
+       */
+      products?: Array<'bic' | 'hot' | 'rateLimit' | 'securityLevel' | 'uaBlock' | 'waf' | 'zoneLockdown'>;
+
+      /**
+       * A mapping of ruleset IDs to a list of rule IDs in that ruleset to skip the
+       * execution of. This option is incompatible with the ruleset option.
+       */
+      rules?: { [key: string]: Array<string> };
+
+      /**
+       * A ruleset to skip the execution of. This option is incompatible with the
+       * rulesets option.
+       */
+      ruleset?: 'current';
+
+      /**
+       * A list of ruleset IDs to skip the execution of. This option is incompatible with
+       * the ruleset and phases options.
+       */
+      rulesets?: Array<string>;
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+}
+
+export interface RuleDeleteParams {
+  /**
+   * The Account ID to use for this endpoint. Mutually exclusive with the Zone ID.
+   */
+  account_id?: string;
+
+  /**
+   * The Zone ID to use for this endpoint. Mutually exclusive with the Account ID.
+   */
+  zone_id?: string;
+}
+
+export type RuleEditParams =
+  | RuleEditParams.BlockRule
+  | RuleEditParams.ChallengeRule
+  | RuleEditParams.ResponseCompressionRule
+  | RuleEditParams.DDoSDynamicRule
+  | RuleEditParams.ExecuteRule
+  | RuleEditParams.ForceConnectionCloseRule
+  | RuleEditParams.JavaScriptChallengeRule
+  | RuleEditParams.LogRule
+  | RuleEditParams.LogCustomFieldRule
+  | RuleEditParams.ManagedChallengeRule
+  | RuleEditParams.RedirectRule
+  | RuleEditParams.RewriteRule
+  | RuleEditParams.RouteRule
+  | RuleEditParams.ScoreRule
+  | RuleEditParams.ServeErrorRule
+  | RuleEditParams.SetCacheSettingsRule
+  | RuleEditParams.SetConfigurationRule
+  | RuleEditParams.SkipRule;
+
+export declare namespace RuleEditParams {
+  export interface BlockRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'block';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: BlockRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: BlockRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: BlockRule.BeforePosition | BlockRule.AfterPosition | BlockRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: BlockRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace BlockRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * The response to show when the block is applied.
+       */
+      response?: ActionParameters.Response;
+    }
+
+    export namespace ActionParameters {
+      /**
+       * The response to show when the block is applied.
+       */
+      export interface Response {
+        /**
+         * The content to return.
+         */
+        content: string;
+
+        /**
+         * The type of the content to return.
+         */
+        content_type: string;
+
+        /**
+         * The status code to return.
+         */
+        status_code: number;
+      }
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface ChallengeRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'challenge';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: ChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: ChallengeRule.BeforePosition | ChallengeRule.AfterPosition | ChallengeRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: ChallengeRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace ChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface ResponseCompressionRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'compress_response';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: ResponseCompressionRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: ResponseCompressionRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?:
+      | ResponseCompressionRule.BeforePosition
+      | ResponseCompressionRule.AfterPosition
+      | ResponseCompressionRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: ResponseCompressionRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace ResponseCompressionRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * Custom order for compression algorithms.
+       */
+      algorithms: Array<ActionParameters.Algorithm>;
+    }
+
+    export namespace ActionParameters {
+      /**
+       * Compression algorithm to enable.
+       */
+      export interface Algorithm {
+        /**
+         * Name of the compression algorithm to enable.
+         */
+        name?: 'none' | 'auto' | 'default' | 'gzip' | 'brotli' | 'zstd';
+      }
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface DDoSDynamicRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'ddos_dynamic';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: DDoSDynamicRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: DDoSDynamicRule.BeforePosition | DDoSDynamicRule.AfterPosition | DDoSDynamicRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: DDoSDynamicRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace DDoSDynamicRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface ExecuteRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'execute';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: ExecuteRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: ExecuteRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: ExecuteRule.BeforePosition | ExecuteRule.AfterPosition | ExecuteRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: ExecuteRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace ExecuteRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * The ID of the ruleset to execute.
+       */
+      id: string;
+
+      /**
+       * The configuration to use for matched data logging.
+       */
+      matched_data?: ActionParameters.MatchedData;
+
+      /**
+       * A set of overrides to apply to the target ruleset.
+       */
+      overrides?: ActionParameters.Overrides;
+    }
+
+    export namespace ActionParameters {
+      /**
+       * The configuration to use for matched data logging.
+       */
+      export interface MatchedData {
+        /**
+         * The public key to encrypt matched data logs with.
+         */
+        public_key: string;
+      }
+
+      /**
+       * A set of overrides to apply to the target ruleset.
+       */
+      export interface Overrides {
+        /**
+         * An action to override all rules with. This option has lower precedence than rule
+         * and category overrides.
+         */
+        action?: string;
+
+        /**
+         * A list of category-level overrides. This option has the second-highest
+         * precedence after rule-level overrides.
+         */
+        categories?: Array<Overrides.Category>;
+
+        /**
+         * Whether to enable execution of all rules. This option has lower precedence than
+         * rule and category overrides.
+         */
+        enabled?: boolean;
+
+        /**
+         * A list of rule-level overrides. This option has the highest precedence.
+         */
+        rules?: Array<Overrides.Rule>;
+
+        /**
+         * A sensitivity level to set for all rules. This option has lower precedence than
+         * rule and category overrides and is only applicable for DDoS phases.
+         */
+        sensitivity_level?: 'default' | 'medium' | 'low' | 'eoff';
+      }
+
+      export namespace Overrides {
+        /**
+         * A category-level override.
+         */
+        export interface Category {
+          /**
+           * The name of the category to override.
+           */
+          category: string;
+
+          /**
+           * The action to override rules in the category with.
+           */
+          action?: string;
+
+          /**
+           * Whether to enable execution of rules in the category.
+           */
+          enabled?: boolean;
+
+          /**
+           * The sensitivity level to use for rules in the category. This option is only
+           * applicable for DDoS phases.
+           */
+          sensitivity_level?: 'default' | 'medium' | 'low' | 'eoff';
+        }
+
+        /**
+         * A rule-level override.
+         */
+        export interface Rule {
+          /**
+           * The ID of the rule to override.
+           */
+          id: string;
+
+          /**
+           * The action to override the rule with.
+           */
+          action?: string;
+
+          /**
+           * Whether to enable execution of the rule.
+           */
+          enabled?: boolean;
+
+          /**
+           * The score threshold to use for the rule.
+           */
+          score_threshold?: number;
+
+          /**
+           * The sensitivity level to use for the rule. This option is only applicable for
+           * DDoS phases.
+           */
+          sensitivity_level?: 'default' | 'medium' | 'low' | 'eoff';
+        }
+      }
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface ForceConnectionCloseRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'force_connection_close';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: ForceConnectionCloseRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?:
+      | ForceConnectionCloseRule.BeforePosition
+      | ForceConnectionCloseRule.AfterPosition
+      | ForceConnectionCloseRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: ForceConnectionCloseRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace ForceConnectionCloseRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface JavaScriptChallengeRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'js_challenge';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: JavaScriptChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?:
+      | JavaScriptChallengeRule.BeforePosition
+      | JavaScriptChallengeRule.AfterPosition
+      | JavaScriptChallengeRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: JavaScriptChallengeRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace JavaScriptChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface LogRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'log';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: LogRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: LogRule.BeforePosition | LogRule.AfterPosition | LogRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: LogRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace LogRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface LogCustomFieldRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'log_custom_field';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: LogCustomFieldRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: LogCustomFieldRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?:
+      | LogCustomFieldRule.BeforePosition
+      | LogCustomFieldRule.AfterPosition
+      | LogCustomFieldRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: LogCustomFieldRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace LogCustomFieldRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * The cookie fields to log.
+       */
+      cookie_fields?: Array<ActionParameters.CookieField>;
+
+      /**
+       * The raw response fields to log.
+       */
+      raw_response_fields?: Array<ActionParameters.RawResponseField>;
+
+      /**
+       * The raw request fields to log.
+       */
+      request_fields?: Array<ActionParameters.RequestField>;
+
+      /**
+       * The transformed response fields to log.
+       */
+      response_fields?: Array<ActionParameters.ResponseField>;
+
+      /**
+       * The transformed request fields to log.
+       */
+      transformed_request_fields?: Array<ActionParameters.TransformedRequestField>;
+    }
+
+    export namespace ActionParameters {
+      /**
+       * The cookie field to log.
+       */
+      export interface CookieField {
+        /**
+         * The name of the cookie.
+         */
+        name: string;
+      }
+
+      /**
+       * The raw response field to log.
+       */
+      export interface RawResponseField {
+        /**
+         * The name of the response header.
+         */
+        name: string;
+
+        /**
+         * Whether to log duplicate values of the same header.
+         */
+        preserve_duplicates?: boolean;
+      }
+
+      /**
+       * The raw request field to log.
+       */
+      export interface RequestField {
+        /**
+         * The name of the header.
+         */
+        name: string;
+      }
+
+      /**
+       * The transformed response field to log.
+       */
+      export interface ResponseField {
+        /**
+         * The name of the response header.
+         */
+        name: string;
+
+        /**
+         * Whether to log duplicate values of the same header.
+         */
+        preserve_duplicates?: boolean;
+      }
+
+      /**
+       * The transformed request field to log.
+       */
+      export interface TransformedRequestField {
+        /**
+         * The name of the header.
+         */
+        name: string;
+      }
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface ManagedChallengeRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'managed_challenge';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: ManagedChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?:
+      | ManagedChallengeRule.BeforePosition
+      | ManagedChallengeRule.AfterPosition
+      | ManagedChallengeRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: ManagedChallengeRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace ManagedChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface RedirectRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'redirect';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: RedirectRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RedirectRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: RedirectRule.BeforePosition | RedirectRule.AfterPosition | RedirectRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RedirectRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RedirectRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * A redirect based on a bulk list lookup.
+       */
+      from_list?: ActionParameters.FromList;
+
+      /**
+       * A redirect based on the request properties.
+       */
+      from_value?: ActionParameters.FromValue;
+    }
+
+    export namespace ActionParameters {
+      /**
+       * A redirect based on a bulk list lookup.
+       */
+      export interface FromList {
+        /**
+         * An expression that evaluates to the list lookup key.
+         */
+        key: string;
+
+        /**
+         * The name of the list to match against.
+         */
+        name: string;
+      }
+
+      /**
+       * A redirect based on the request properties.
+       */
+      export interface FromValue {
+        /**
+         * A URL to redirect the request to.
+         */
+        target_url: FromValue.TargetURL;
+
+        /**
+         * Whether to keep the query string of the original request.
+         */
+        preserve_query_string?: boolean;
+
+        /**
+         * The status code to use for the redirect.
+         */
+        status_code?: 301 | 302 | 303 | 307 | 308;
+      }
+
+      export namespace FromValue {
+        /**
+         * A URL to redirect the request to.
+         */
+        export interface TargetURL {
+          /**
+           * An expression that evaluates to a URL to redirect the request to.
+           */
+          expression?: string;
+
+          /**
+           * A URL to redirect the request to.
+           */
+          value?: string;
+        }
+      }
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface RewriteRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'rewrite';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: RewriteRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RewriteRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: RewriteRule.BeforePosition | RewriteRule.AfterPosition | RewriteRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RewriteRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RewriteRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * A map of headers to rewrite.
+       */
+      headers?: {
+        [key: string]:
+          | ActionParameters.AddStaticHeader
+          | ActionParameters.AddDynamicHeader
+          | ActionParameters.SetStaticHeader
+          | ActionParameters.SetDynamicHeader
+          | ActionParameters.RemoveHeader;
+      };
+
+      /**
+       * A URI path rewrite.
+       */
+      uri?: ActionParameters.URIPath | ActionParameters.URIQuery;
+    }
+
+    export namespace ActionParameters {
+      /**
+       * A header with a static value to add.
+       */
+      export interface AddStaticHeader {
+        /**
+         * The operation to perform on the header.
+         */
+        operation: 'add';
+
+        /**
+         * A static value for the header.
+         */
+        value: string;
+      }
+
+      /**
+       * A header with a dynamic value to add.
+       */
+      export interface AddDynamicHeader {
+        /**
+         * An expression that evaluates to a value for the header.
+         */
+        expression: string;
+
+        /**
+         * The operation to perform on the header.
+         */
+        operation: 'add';
+      }
+
+      /**
+       * A header with a static value to set.
+       */
+      export interface SetStaticHeader {
+        /**
+         * The operation to perform on the header.
+         */
+        operation: 'set';
+
+        /**
+         * A static value for the header.
+         */
+        value: string;
+      }
+
+      /**
+       * A header with a dynamic value to set.
+       */
+      export interface SetDynamicHeader {
+        /**
+         * An expression that evaluates to a value for the header.
+         */
+        expression: string;
+
+        /**
+         * The operation to perform on the header.
+         */
+        operation: 'set';
+      }
+
+      /**
+       * A header to remove.
+       */
+      export interface RemoveHeader {
+        /**
+         * The operation to perform on the header.
+         */
+        operation: 'remove';
+      }
+
+      /**
+       * A URI path rewrite.
+       */
+      export interface URIPath {
+        /**
+         * A URI path rewrite.
+         */
+        path: URIPath.Path;
+      }
+
+      export namespace URIPath {
+        /**
+         * A URI path rewrite.
+         */
+        export interface Path {
+          /**
+           * An expression that evaluates to a value to rewrite the URI path to.
+           */
+          expression?: string;
+
+          /**
+           * A value to rewrite the URI path to.
+           */
+          value?: string;
+        }
+      }
+
+      /**
+       * A URI query rewrite.
+       */
+      export interface URIQuery {
+        /**
+         * A URI query rewrite.
+         */
+        query: URIQuery.Query;
+      }
+
+      export namespace URIQuery {
+        /**
+         * A URI query rewrite.
+         */
+        export interface Query {
+          /**
+           * An expression that evaluates to a value to rewrite the URI query to.
+           */
+          expression?: string;
+
+          /**
+           * A value to rewrite the URI query to.
+           */
+          value?: string;
+        }
+      }
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface RouteRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'route';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: RouteRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RouteRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: RouteRule.BeforePosition | RouteRule.AfterPosition | RouteRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RouteRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RouteRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * A value to rewrite the HTTP host header to.
+       */
+      host_header?: string;
+
+      /**
+       * An origin to route to.
+       */
+      origin?: ActionParameters.Origin;
+
+      /**
+       * A Server Name Indication (SNI) override.
+       */
+      sni?: ActionParameters.SNI;
+    }
+
+    export namespace ActionParameters {
+      /**
+       * An origin to route to.
+       */
+      export interface Origin {
+        /**
+         * A resolved host to route to.
+         */
+        host?: string;
+
+        /**
+         * A destination port to route to.
+         */
+        port?: number;
+      }
+
+      /**
+       * A Server Name Indication (SNI) override.
+       */
+      export interface SNI {
+        /**
+         * A value to override the SNI to.
+         */
+        value: string;
+      }
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface ScoreRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'score';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: ScoreRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: ScoreRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: ScoreRule.BeforePosition | ScoreRule.AfterPosition | ScoreRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: ScoreRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace ScoreRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * A delta to change the score by, which can be either positive or negative.
+       */
+      increment: number;
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface ServeErrorRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'serve_error';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: ServeErrorRule.ActionParametersContent | ServeErrorRule.ActionParametersAsset;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: ServeErrorRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: ServeErrorRule.BeforePosition | ServeErrorRule.AfterPosition | ServeErrorRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: ServeErrorRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace ServeErrorRule {
+    export interface ActionParametersContent {
+      /**
+       * The response content.
+       */
+      content: string;
+
+      /**
+       * The content type header to set with the error response.
+       */
+      content_type?: 'application/json' | 'text/html' | 'text/plain' | 'text/xml';
+
+      /**
+       * The status code to use for the error.
+       */
+      status_code?: number;
+    }
+
+    export interface ActionParametersAsset {
+      /**
+       * The name of a custom asset to serve as the error response.
+       */
+      asset_name: string;
+
+      /**
+       * The content type header to set with the error response.
+       */
+      content_type?: 'application/json' | 'text/html' | 'text/plain' | 'text/xml';
+
+      /**
+       * The status code to use for the error.
+       */
+      status_code?: number;
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface SetCacheSettingsRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'set_cache_settings';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: SetCacheSettingsRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: SetCacheSettingsRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?:
+      | SetCacheSettingsRule.BeforePosition
+      | SetCacheSettingsRule.AfterPosition
+      | SetCacheSettingsRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: SetCacheSettingsRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace SetCacheSettingsRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * A list of additional ports that caching should be enabled on.
+       */
+      additional_cacheable_ports?: Array<number>;
+
+      /**
+       * How long client browsers should cache the response. Cloudflare cache purge will
+       * not purge content cached on client browsers, so high browser TTLs may lead to
+       * stale content.
+       */
+      browser_ttl?: ActionParameters.BrowserTTL;
+
+      /**
+       * Whether the request's response from the origin is eligible for caching. Caching
+       * itself will still depend on the cache control header and your other caching
+       * configurations.
+       */
+      cache?: boolean;
+
+      /**
+       * Which components of the request are included in or excluded from the cache key
+       * Cloudflare uses to store the response in cache.
+       */
+      cache_key?: ActionParameters.CacheKey;
+
+      /**
+       * Settings to determine whether the request's response from origin is eligible for
+       * Cache Reserve (requires a Cache Reserve add-on plan).
+       */
+      cache_reserve?: ActionParameters.CacheReserve;
+
+      /**
+       * How long the Cloudflare edge network should cache the response.
+       */
+      edge_ttl?: ActionParameters.EdgeTTL;
+
+      /**
+       * Whether Cloudflare will aim to strictly adhere to RFC 7234.
+       */
+      origin_cache_control?: boolean;
+
+      /**
+       * Whether to generate Cloudflare error pages for issues from the origin server.
+       */
+      origin_error_page_passthru?: boolean;
+
+      /**
+       * A timeout value between two successive read operations to use for your origin
+       * server. Historically, the timeout value between two read options from Cloudflare
+       * to an origin server is 100 seconds. If you are attempting to reduce HTTP 524
+       * errors because of timeouts from an origin server, try increasing this timeout
+       * value.
+       */
+      read_timeout?: number;
+
+      /**
+       * Whether Cloudflare should respect strong ETag (entity tag) headers. If false,
+       * Cloudflare converts strong ETag headers to weak ETag headers.
+       */
+      respect_strong_etags?: boolean;
+
+      /**
+       * When to serve stale content from cache.
+       */
+      serve_stale?: ActionParameters.ServeStale;
+    }
+
+    export namespace ActionParameters {
+      /**
+       * How long client browsers should cache the response. Cloudflare cache purge will
+       * not purge content cached on client browsers, so high browser TTLs may lead to
+       * stale content.
+       */
+      export interface BrowserTTL {
+        /**
+         * The browser TTL mode.
+         */
+        mode: 'respect_origin' | 'bypass_by_default' | 'override_origin' | 'bypass';
+
+        /**
+         * The browser TTL (in seconds) if you choose the "override_origin" mode.
+         */
+        default?: number;
+      }
+
+      /**
+       * Which components of the request are included in or excluded from the cache key
+       * Cloudflare uses to store the response in cache.
+       */
+      export interface CacheKey {
+        /**
+         * Whether to separate cached content based on the visitor's device type.
+         */
+        cache_by_device_type?: boolean;
+
+        /**
+         * Whether to protect from web cache deception attacks, while allowing static
+         * assets to be cached.
+         */
+        cache_deception_armor?: boolean;
+
+        /**
+         * Which components of the request are included or excluded from the cache key.
+         */
+        custom_key?: CacheKey.CustomKey;
+
+        /**
+         * Whether to treat requests with the same query parameters the same, regardless of
+         * the order those query parameters are in.
+         */
+        ignore_query_strings_order?: boolean;
+      }
+
+      export namespace CacheKey {
+        /**
+         * Which components of the request are included or excluded from the cache key.
+         */
+        export interface CustomKey {
+          /**
+           * Which cookies to include in the cache key.
+           */
+          cookie?: CustomKey.Cookie;
+
+          /**
+           * Which headers to include in the cache key.
+           */
+          header?: CustomKey.Header;
+
+          /**
+           * How to use the host in the cache key.
+           */
+          host?: CustomKey.Host;
+
+          /**
+           * Which query string parameters to include in or exclude from the cache key.
+           */
+          query_string?: CustomKey.QueryString;
+
+          /**
+           * How to use characteristics of the request user agent in the cache key.
+           */
+          user?: CustomKey.User;
+        }
+
+        export namespace CustomKey {
+          /**
+           * Which cookies to include in the cache key.
+           */
+          export interface Cookie {
+            /**
+             * A list of cookies to check for the presence of. The presence of these cookies is
+             * included in the cache key.
+             */
+            check_presence?: Array<string>;
+
+            /**
+             * A list of cookies to include in the cache key.
+             */
+            include?: Array<string>;
+          }
+
+          /**
+           * Which headers to include in the cache key.
+           */
+          export interface Header {
+            /**
+             * A list of headers to check for the presence of. The presence of these headers is
+             * included in the cache key.
+             */
+            check_presence?: Array<string>;
+
+            /**
+             * A mapping of header names to a list of values. If a header is present in the
+             * request and contains any of the values provided, its value is included in the
+             * cache key.
+             */
+            contains?: { [key: string]: Array<string> };
+
+            /**
+             * Whether to exclude the origin header in the cache key.
+             */
+            exclude_origin?: boolean;
+
+            /**
+             * A list of headers to include in the cache key.
+             */
+            include?: Array<string>;
+          }
+
+          /**
+           * How to use the host in the cache key.
+           */
+          export interface Host {
+            /**
+             * Whether to use the resolved host in the cache key.
+             */
+            resolved?: boolean;
+          }
+
+          /**
+           * Which query string parameters to include in or exclude from the cache key.
+           */
+          export interface QueryString {
+            /**
+             * Which query string parameters to exclude from the cache key.
+             */
+            exclude?: QueryString.Exclude;
+
+            /**
+             * Which query string parameters to include in the cache key.
+             */
+            include?: QueryString.Include;
+          }
+
+          export namespace QueryString {
+            /**
+             * Which query string parameters to exclude from the cache key.
+             */
+            export interface Exclude {
+              /**
+               * Whether to exclude all query string parameters from the cache key.
+               */
+              all?: true;
+
+              /**
+               * A list of query string parameters to exclude from the cache key.
+               */
+              list?: Array<string>;
+            }
+
+            /**
+             * Which query string parameters to include in the cache key.
+             */
+            export interface Include {
+              /**
+               * Whether to include all query string parameters in the cache key.
+               */
+              all?: true;
+
+              /**
+               * A list of query string parameters to include in the cache key.
+               */
+              list?: Array<string>;
+            }
+          }
+
+          /**
+           * How to use characteristics of the request user agent in the cache key.
+           */
+          export interface User {
+            /**
+             * Whether to use the user agent's device type in the cache key.
+             */
+            device_type?: boolean;
+
+            /**
+             * Whether to use the user agents's country in the cache key.
+             */
+            geo?: boolean;
+
+            /**
+             * Whether to use the user agent's language in the cache key.
+             */
+            lang?: boolean;
+          }
+        }
+      }
+
+      /**
+       * Settings to determine whether the request's response from origin is eligible for
+       * Cache Reserve (requires a Cache Reserve add-on plan).
+       */
+      export interface CacheReserve {
+        /**
+         * Whether Cache Reserve is enabled. If this is true and a request meets
+         * eligibility criteria, Cloudflare will write the resource to Cache Reserve.
+         */
+        eligible: boolean;
+
+        /**
+         * The minimum file size eligible for storage in Cache Reserve.
+         */
+        minimum_file_size?: number;
+      }
+
+      /**
+       * How long the Cloudflare edge network should cache the response.
+       */
+      export interface EdgeTTL {
+        /**
+         * The edge TTL mode.
+         */
+        mode: 'respect_origin' | 'bypass_by_default' | 'override_origin';
+
+        /**
+         * The edge TTL (in seconds) if you choose the "override_origin" mode.
+         */
+        default?: number;
+
+        /**
+         * A list of TTLs to apply to specific status codes or status code ranges.
+         */
+        status_code_ttl?: Array<EdgeTTL.StatusCodeTTL>;
+      }
+
+      export namespace EdgeTTL {
+        export interface StatusCodeTTL {
+          /**
+           * The time to cache the response for (in seconds). A value of 0 is equivalent to
+           * setting the cache control header with the value "no-cache". A value of -1 is
+           * equivalent to setting the cache control header with the value of "no-store".
+           */
+          value: number;
+
+          /**
+           * A single status code to apply the TTL to.
+           */
+          status_code?: number;
+
+          /**
+           * A range of status codes to apply the TTL to.
+           */
+          status_code_range?: StatusCodeTTL.StatusCodeRange;
+        }
+
+        export namespace StatusCodeTTL {
+          /**
+           * A range of status codes to apply the TTL to.
+           */
+          export interface StatusCodeRange {
+            /**
+             * The lower bound of the range.
+             */
+            from?: number;
+
+            /**
+             * The upper bound of the range.
+             */
+            to?: number;
+          }
+        }
+      }
+
+      /**
+       * When to serve stale content from cache.
+       */
+      export interface ServeStale {
+        /**
+         * Whether Cloudflare should disable serving stale content while getting the latest
+         * content from the origin.
+         */
+        disable_stale_while_updating?: boolean;
+      }
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface SetConfigurationRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'set_config';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: SetConfigurationRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: SetConfigurationRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?:
+      | SetConfigurationRule.BeforePosition
+      | SetConfigurationRule.AfterPosition
+      | SetConfigurationRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: SetConfigurationRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace SetConfigurationRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * Whether to enable Automatic HTTPS Rewrites.
+       */
+      automatic_https_rewrites?: boolean;
+
+      /**
+       * Which file extensions to minify automatically.
+       */
+      autominify?: ActionParameters.Autominify;
+
+      /**
+       * Whether to enable Browser Integrity Check (BIC).
+       */
+      bic?: boolean;
+
+      /**
+       * @deprecated Cloudflare Apps are deprected.
+       */
+      disable_apps?: true;
+
+      /**
+       * Whether to disable Pay Per Crawl.
+       */
+      disable_pay_per_crawl?: true;
+
+      /**
+       * Whether to disable Real User Monitoring (RUM).
+       */
+      disable_rum?: true;
+
+      /**
+       * Whether to disable Zaraz.
+       */
+      disable_zaraz?: true;
+
+      /**
+       * Whether to enable Email Obfuscation.
+       */
+      email_obfuscation?: boolean;
+
+      /**
+       * Whether to enable Cloudflare Fonts.
+       */
+      fonts?: boolean;
+
+      /**
+       * Whether to enable Hotlink Protection.
+       */
+      hotlink_protection?: boolean;
+
+      /**
+       * @deprecated Mirage is deprecated. More information at
+       * https://developers.cloudflare.com/speed/optimization/images/mirage/.
+       */
+      mirage?: boolean;
+
+      /**
+       * Whether to enable Opportunistic Encryption.
+       */
+      opportunistic_encryption?: boolean;
+
+      /**
+       * The Polish level to configure.
+       */
+      polish?: 'off' | 'lossless' | 'lossy' | 'webp';
+
+      /**
+       * The request body buffering mode.
+       */
+      request_body_buffering?: 'none' | 'standard' | 'full';
+
+      /**
+       * The response body buffering mode.
+       */
+      response_body_buffering?: 'none' | 'standard';
+
+      /**
+       * Whether to enable Rocket Loader.
+       */
+      rocket_loader?: boolean;
+
+      /**
+       * The Security Level to configure.
+       */
+      security_level?: 'off' | 'essentially_off' | 'low' | 'medium' | 'high' | 'under_attack';
+
+      /**
+       * Whether to enable Server-Side Excludes.
+       */
+      server_side_excludes?: boolean;
+
+      /**
+       * The SSL level to configure.
+       */
+      ssl?: 'off' | 'flexible' | 'full' | 'strict' | 'origin_pull';
+
+      /**
+       * Whether to enable Signed Exchanges (SXG).
+       */
+      sxg?: boolean;
+    }
+
+    export namespace ActionParameters {
+      /**
+       * Which file extensions to minify automatically.
+       */
+      export interface Autominify {
+        /**
+         * Whether to minify CSS files.
+         */
+        css?: boolean;
+
+        /**
+         * Whether to minify HTML files.
+         */
+        html?: boolean;
+
+        /**
+         * Whether to minify JavaScript files.
+         */
+        js?: boolean;
+      }
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface SkipRule {
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * Body param: The action to perform when the rule matches.
+     */
+    action?: 'skip';
+
+    /**
+     * Body param: The parameters configuring the rule's action.
+     */
+    action_parameters?: SkipRule.ActionParameters;
+
+    /**
+     * Body param: An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Body param: Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Body param: Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: SkipRule.ExposedCredentialCheck;
+
+    /**
+     * Body param: The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * Body param: An object configuring the rule's logging behavior.
+     */
+    logging?: LoggingParam;
+
+    /**
+     * Body param: An object configuring where the rule will be placed.
+     */
+    position?: SkipRule.BeforePosition | SkipRule.AfterPosition | SkipRule.IndexPosition;
+
+    /**
+     * Body param: An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: SkipRule.Ratelimit;
+
+    /**
+     * Body param: The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace SkipRule {
+    /**
+     * The parameters configuring the rule's action.
+     */
+    export interface ActionParameters {
+      /**
+       * A phase to skip the execution of. This option is only compatible with the
+       * products option.
+       */
+      phase?: 'current';
+
+      /**
+       * A list of phases to skip the execution of. This option is incompatible with the
+       * rulesets option.
+       */
+      phases?: Array<RulesetsAPI.PhaseParam>;
+
+      /**
+       * A list of legacy security products to skip the execution of.
+       */
+      products?: Array<'bic' | 'hot' | 'rateLimit' | 'securityLevel' | 'uaBlock' | 'waf' | 'zoneLockdown'>;
+
+      /**
+       * A mapping of ruleset IDs to a list of rule IDs in that ruleset to skip the
+       * execution of. This option is incompatible with the ruleset option.
+       */
+      rules?: { [key: string]: Array<string> };
+
+      /**
+       * A ruleset to skip the execution of. This option is incompatible with the
+       * rulesets option.
+       */
+      ruleset?: 'current';
+
+      /**
+       * A list of ruleset IDs to skip the execution of. This option is incompatible with
+       * the ruleset and phases options.
+       */
+      rulesets?: Array<string>;
+    }
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface BeforePosition {
+      /**
+       * The ID of another rule to place the rule before. An empty value causes the rule
+       * to be placed at the top.
+       */
+      before?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface AfterPosition {
+      /**
+       * The ID of another rule to place the rule after. An empty value causes the rule
+       * to be placed at the bottom.
+       */
+      after?: string;
+    }
+
+    /**
+     * An object configuring where the rule will be placed.
+     */
+    export interface IndexPosition {
+      /**
+       * An index at which to place the rule, where index 1 is the first rule.
+       */
+      index?: number;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+}
+
 export declare namespace Rules {
   export {
     type BlockRule as BlockRule,
@@ -3490,5 +16030,11 @@ export declare namespace Rules {
     type SetCacheSettingsRule as SetCacheSettingsRule,
     type SetConfigRule as SetConfigRule,
     type SkipRule as SkipRule,
+    type RuleCreateResponse as RuleCreateResponse,
+    type RuleDeleteResponse as RuleDeleteResponse,
+    type RuleEditResponse as RuleEditResponse,
+    type RuleCreateParams as RuleCreateParams,
+    type RuleDeleteParams as RuleDeleteParams,
+    type RuleEditParams as RuleEditParams,
   };
 }

--- a/src/resources/rulesets/rulesets.ts
+++ b/src/resources/rulesets/rulesets.ts
@@ -1,6 +1,8 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';
+import { isRequestOptions } from '../../core';
+import * as Core from '../../core';
 import * as RulesAPI from './rules';
 import {
   BlockRule,
@@ -15,6 +17,12 @@ import {
   RedirectRule,
   RewriteRule,
   RouteRule,
+  RuleCreateParams,
+  RuleCreateResponse,
+  RuleDeleteParams,
+  RuleDeleteResponse,
+  RuleEditParams,
+  RuleEditResponse,
   Rules,
   RulesetRule,
   ScoreRule,
@@ -24,20 +32,272 @@ import {
   SkipRule,
 } from './rules';
 import * as VersionsAPI from './versions';
-import { Versions } from './versions';
+import {
+  VersionDeleteParams,
+  VersionGetParams,
+  VersionGetResponse,
+  VersionListParams,
+  VersionListResponse,
+  VersionListResponsesSinglePage,
+  Versions,
+} from './versions';
 import * as PhasesAPI from './phases/phases';
-import { Phases } from './phases/phases';
+import {
+  PhaseGetParams,
+  PhaseGetResponse,
+  PhaseUpdateParams,
+  PhaseUpdateResponse,
+  Phases,
+} from './phases/phases';
+import { CloudflareError } from '../../error';
+import { CursorPagination, type CursorPaginationParams } from '../../pagination';
 
 export class Rulesets extends APIResource {
   phases: PhasesAPI.Phases = new PhasesAPI.Phases(this._client);
   rules: RulesAPI.Rules = new RulesAPI.Rules(this._client);
   versions: VersionsAPI.Versions = new VersionsAPI.Versions(this._client);
+
+  /**
+   * Creates a ruleset.
+   *
+   * @example
+   * ```ts
+   * const ruleset = await client.rulesets.create({
+   *   kind: 'root',
+   *   name: 'My ruleset',
+   *   phase: 'http_request_firewall_custom',
+   *   account_id: 'account_id',
+   * });
+   * ```
+   */
+  create(params: RulesetCreateParams, options?: Core.RequestOptions): Core.APIPromise<RulesetCreateResponse> {
+    const { account_id, zone_id, ...body } = params;
+    if (!account_id && !zone_id) {
+      throw new CloudflareError('You must provide either account_id or zone_id.');
+    }
+    if (account_id && zone_id) {
+      throw new CloudflareError('You cannot provide both account_id and zone_id.');
+    }
+    const { accountOrZone, accountOrZoneId } =
+      account_id ?
+        {
+          accountOrZone: 'accounts',
+          accountOrZoneId: account_id,
+        }
+      : {
+          accountOrZone: 'zones',
+          accountOrZoneId: zone_id,
+        };
+    return (
+      this._client.post(`/${accountOrZone}/${accountOrZoneId}/rulesets`, {
+        body,
+        ...options,
+      }) as Core.APIPromise<{ result: RulesetCreateResponse }>
+    )._thenUnwrap((obj) => obj.result);
+  }
+
+  /**
+   * Updates an account or zone ruleset, creating a new version.
+   *
+   * @example
+   * ```ts
+   * const ruleset = await client.rulesets.update(
+   *   '2f2feab2026849078ba485f918791bdc',
+   *   { account_id: 'account_id' },
+   * );
+   * ```
+   */
+  update(
+    rulesetId: string,
+    params: RulesetUpdateParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<RulesetUpdateResponse> {
+    const { account_id, zone_id, ...body } = params;
+    if (!account_id && !zone_id) {
+      throw new CloudflareError('You must provide either account_id or zone_id.');
+    }
+    if (account_id && zone_id) {
+      throw new CloudflareError('You cannot provide both account_id and zone_id.');
+    }
+    const { accountOrZone, accountOrZoneId } =
+      account_id ?
+        {
+          accountOrZone: 'accounts',
+          accountOrZoneId: account_id,
+        }
+      : {
+          accountOrZone: 'zones',
+          accountOrZoneId: zone_id,
+        };
+    return (
+      this._client.put(`/${accountOrZone}/${accountOrZoneId}/rulesets/${rulesetId}`, {
+        body,
+        ...options,
+      }) as Core.APIPromise<{ result: RulesetUpdateResponse }>
+    )._thenUnwrap((obj) => obj.result);
+  }
+
+  /**
+   * Fetches all rulesets.
+   *
+   * @example
+   * ```ts
+   * // Automatically fetches more pages as needed.
+   * for await (const rulesetListResponse of client.rulesets.list(
+   *   { account_id: 'account_id' },
+   * )) {
+   *   // ...
+   * }
+   * ```
+   */
+  list(
+    params?: RulesetListParams,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<RulesetListResponsesCursorPagination, RulesetListResponse>;
+  list(
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<RulesetListResponsesCursorPagination, RulesetListResponse>;
+  list(
+    params: RulesetListParams | Core.RequestOptions = {},
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<RulesetListResponsesCursorPagination, RulesetListResponse> {
+    if (isRequestOptions(params)) {
+      return this.list({}, params);
+    }
+    const { account_id, zone_id, ...query } = params;
+    if (!account_id && !zone_id) {
+      throw new CloudflareError('You must provide either account_id or zone_id.');
+    }
+    if (account_id && zone_id) {
+      throw new CloudflareError('You cannot provide both account_id and zone_id.');
+    }
+    const { accountOrZone, accountOrZoneId } =
+      account_id ?
+        {
+          accountOrZone: 'accounts',
+          accountOrZoneId: account_id,
+        }
+      : {
+          accountOrZone: 'zones',
+          accountOrZoneId: zone_id,
+        };
+    return this._client.getAPIList(
+      `/${accountOrZone}/${accountOrZoneId}/rulesets`,
+      RulesetListResponsesCursorPagination,
+      { query, ...options },
+    );
+  }
+
+  /**
+   * Deletes all versions of an existing account or zone ruleset.
+   *
+   * @example
+   * ```ts
+   * await client.rulesets.delete(
+   *   '2f2feab2026849078ba485f918791bdc',
+   *   { account_id: 'account_id' },
+   * );
+   * ```
+   */
+  delete(
+    rulesetId: string,
+    params?: RulesetDeleteParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<void>;
+  delete(rulesetId: string, options?: Core.RequestOptions): Core.APIPromise<void>;
+  delete(
+    rulesetId: string,
+    params: RulesetDeleteParams | Core.RequestOptions = {},
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<void> {
+    if (isRequestOptions(params)) {
+      return this.delete(rulesetId, {}, params);
+    }
+    const { account_id, zone_id } = params;
+    if (!account_id && !zone_id) {
+      throw new CloudflareError('You must provide either account_id or zone_id.');
+    }
+    if (account_id && zone_id) {
+      throw new CloudflareError('You cannot provide both account_id and zone_id.');
+    }
+    const { accountOrZone, accountOrZoneId } =
+      account_id ?
+        {
+          accountOrZone: 'accounts',
+          accountOrZoneId: account_id,
+        }
+      : {
+          accountOrZone: 'zones',
+          accountOrZoneId: zone_id,
+        };
+    return this._client.delete(`/${accountOrZone}/${accountOrZoneId}/rulesets/${rulesetId}`, {
+      ...options,
+      headers: { Accept: '*/*', ...options?.headers },
+    });
+  }
+
+  /**
+   * Fetches the latest version of an account or zone ruleset.
+   *
+   * @example
+   * ```ts
+   * const ruleset = await client.rulesets.get(
+   *   '2f2feab2026849078ba485f918791bdc',
+   *   { account_id: 'account_id' },
+   * );
+   * ```
+   */
+  get(
+    rulesetId: string,
+    params?: RulesetGetParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<RulesetGetResponse>;
+  get(rulesetId: string, options?: Core.RequestOptions): Core.APIPromise<RulesetGetResponse>;
+  get(
+    rulesetId: string,
+    params: RulesetGetParams | Core.RequestOptions = {},
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<RulesetGetResponse> {
+    if (isRequestOptions(params)) {
+      return this.get(rulesetId, {}, params);
+    }
+    const { account_id, zone_id } = params;
+    if (!account_id && !zone_id) {
+      throw new CloudflareError('You must provide either account_id or zone_id.');
+    }
+    if (account_id && zone_id) {
+      throw new CloudflareError('You cannot provide both account_id and zone_id.');
+    }
+    const { accountOrZone, accountOrZoneId } =
+      account_id ?
+        {
+          accountOrZone: 'accounts',
+          accountOrZoneId: account_id,
+        }
+      : {
+          accountOrZone: 'zones',
+          accountOrZoneId: zone_id,
+        };
+    return (
+      this._client.get(
+        `/${accountOrZone}/${accountOrZoneId}/rulesets/${rulesetId}`,
+        options,
+      ) as Core.APIPromise<{ result: RulesetGetResponse }>
+    )._thenUnwrap((obj) => obj.result);
+  }
 }
+
+export class RulesetListResponsesCursorPagination extends CursorPagination<RulesetListResponse> {}
 
 /**
  * The kind of the ruleset.
  */
 export type Kind = 'managed' | 'custom' | 'root' | 'zone';
+
+/**
+ * The kind of the ruleset.
+ */
+export type KindParam = 'managed' | 'custom' | 'root' | 'zone';
 
 /**
  * The phase of the ruleset.
@@ -59,7 +319,34 @@ export type Phase =
   | 'http_request_sanitize'
   | 'http_request_sbfm'
   | 'http_request_transform'
-  | 'http_response_cache_settings'
+  | 'http_response_compression'
+  | 'http_response_firewall_managed'
+  | 'http_response_headers_transform'
+  | 'magic_transit'
+  | 'magic_transit_ids_managed'
+  | 'magic_transit_managed'
+  | 'magic_transit_ratelimit';
+
+/**
+ * The phase of the ruleset.
+ */
+export type PhaseParam =
+  | 'ddos_l4'
+  | 'ddos_l7'
+  | 'http_config_settings'
+  | 'http_custom_errors'
+  | 'http_log_custom_fields'
+  | 'http_ratelimit'
+  | 'http_request_cache_settings'
+  | 'http_request_dynamic_redirect'
+  | 'http_request_firewall_custom'
+  | 'http_request_firewall_managed'
+  | 'http_request_late_transform'
+  | 'http_request_origin'
+  | 'http_request_redirect'
+  | 'http_request_sanitize'
+  | 'http_request_sbfm'
+  | 'http_request_transform'
   | 'http_response_compression'
   | 'http_response_firewall_managed'
   | 'http_response_headers_transform'
@@ -98,14 +385,1722 @@ export interface Ruleset {
   name?: string;
 }
 
+/**
+ * A ruleset object.
+ */
+export interface RulesetCreateResponse {
+  /**
+   * The unique ID of the ruleset.
+   */
+  id: string;
+
+  /**
+   * The kind of the ruleset.
+   */
+  kind: Kind;
+
+  /**
+   * The timestamp of when the ruleset was last modified.
+   */
+  last_updated: string;
+
+  /**
+   * The human-readable name of the ruleset.
+   */
+  name: string;
+
+  /**
+   * The phase of the ruleset.
+   */
+  phase: Phase;
+
+  /**
+   * The list of rules in the ruleset.
+   */
+  rules: Array<
+    | RulesAPI.BlockRule
+    | RulesetCreateResponse.RulesetsChallengeRule
+    | RulesAPI.CompressResponseRule
+    | RulesAPI.DDoSDynamicRule
+    | RulesAPI.ExecuteRule
+    | RulesAPI.ForceConnectionCloseRule
+    | RulesetCreateResponse.RulesetsJSChallengeRule
+    | RulesAPI.LogRule
+    | RulesAPI.LogCustomFieldRule
+    | RulesAPI.ManagedChallengeRule
+    | RulesAPI.RedirectRule
+    | RulesAPI.RewriteRule
+    | RulesAPI.RouteRule
+    | RulesAPI.ScoreRule
+    | RulesAPI.ServeErrorRule
+    | RulesAPI.SetCacheSettingsRule
+    | RulesAPI.SetConfigRule
+    | RulesAPI.SkipRule
+  >;
+
+  /**
+   * The version of the ruleset.
+   */
+  version: string;
+
+  /**
+   * An informative description of the ruleset.
+   */
+  description?: string;
+}
+
+export namespace RulesetCreateResponse {
+  export interface RulesetsChallengeRule {
+    /**
+     * The timestamp of when the rule was last modified.
+     */
+    last_updated: string;
+
+    /**
+     * The version of the rule.
+     */
+    version: string;
+
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * The categories of the rule.
+     */
+    categories?: Array<string>;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.Logging;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface RulesetsJSChallengeRule {
+    /**
+     * The timestamp of when the rule was last modified.
+     */
+    last_updated: string;
+
+    /**
+     * The version of the rule.
+     */
+    version: string;
+
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'js_challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * The categories of the rule.
+     */
+    categories?: Array<string>;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsJSChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.Logging;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsJSChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsJSChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+}
+
+/**
+ * A ruleset object.
+ */
+export interface RulesetUpdateResponse {
+  /**
+   * The unique ID of the ruleset.
+   */
+  id: string;
+
+  /**
+   * The kind of the ruleset.
+   */
+  kind: Kind;
+
+  /**
+   * The timestamp of when the ruleset was last modified.
+   */
+  last_updated: string;
+
+  /**
+   * The human-readable name of the ruleset.
+   */
+  name: string;
+
+  /**
+   * The phase of the ruleset.
+   */
+  phase: Phase;
+
+  /**
+   * The list of rules in the ruleset.
+   */
+  rules: Array<
+    | RulesAPI.BlockRule
+    | RulesetUpdateResponse.RulesetsChallengeRule
+    | RulesAPI.CompressResponseRule
+    | RulesAPI.DDoSDynamicRule
+    | RulesAPI.ExecuteRule
+    | RulesAPI.ForceConnectionCloseRule
+    | RulesetUpdateResponse.RulesetsJSChallengeRule
+    | RulesAPI.LogRule
+    | RulesAPI.LogCustomFieldRule
+    | RulesAPI.ManagedChallengeRule
+    | RulesAPI.RedirectRule
+    | RulesAPI.RewriteRule
+    | RulesAPI.RouteRule
+    | RulesAPI.ScoreRule
+    | RulesAPI.ServeErrorRule
+    | RulesAPI.SetCacheSettingsRule
+    | RulesAPI.SetConfigRule
+    | RulesAPI.SkipRule
+  >;
+
+  /**
+   * The version of the ruleset.
+   */
+  version: string;
+
+  /**
+   * An informative description of the ruleset.
+   */
+  description?: string;
+}
+
+export namespace RulesetUpdateResponse {
+  export interface RulesetsChallengeRule {
+    /**
+     * The timestamp of when the rule was last modified.
+     */
+    last_updated: string;
+
+    /**
+     * The version of the rule.
+     */
+    version: string;
+
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * The categories of the rule.
+     */
+    categories?: Array<string>;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.Logging;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface RulesetsJSChallengeRule {
+    /**
+     * The timestamp of when the rule was last modified.
+     */
+    last_updated: string;
+
+    /**
+     * The version of the rule.
+     */
+    version: string;
+
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'js_challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * The categories of the rule.
+     */
+    categories?: Array<string>;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsJSChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.Logging;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsJSChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsJSChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+}
+
+/**
+ * A ruleset object.
+ */
+export interface RulesetListResponse {
+  /**
+   * The unique ID of the ruleset.
+   */
+  id: string;
+
+  /**
+   * The kind of the ruleset.
+   */
+  kind: Kind;
+
+  /**
+   * The timestamp of when the ruleset was last modified.
+   */
+  last_updated: string;
+
+  /**
+   * The human-readable name of the ruleset.
+   */
+  name: string;
+
+  /**
+   * The phase of the ruleset.
+   */
+  phase: Phase;
+
+  /**
+   * The version of the ruleset.
+   */
+  version: string;
+
+  /**
+   * An informative description of the ruleset.
+   */
+  description?: string;
+}
+
+/**
+ * A ruleset object.
+ */
+export interface RulesetGetResponse {
+  /**
+   * The unique ID of the ruleset.
+   */
+  id: string;
+
+  /**
+   * The kind of the ruleset.
+   */
+  kind: Kind;
+
+  /**
+   * The timestamp of when the ruleset was last modified.
+   */
+  last_updated: string;
+
+  /**
+   * The human-readable name of the ruleset.
+   */
+  name: string;
+
+  /**
+   * The phase of the ruleset.
+   */
+  phase: Phase;
+
+  /**
+   * The list of rules in the ruleset.
+   */
+  rules: Array<
+    | RulesAPI.BlockRule
+    | RulesetGetResponse.RulesetsChallengeRule
+    | RulesAPI.CompressResponseRule
+    | RulesAPI.DDoSDynamicRule
+    | RulesAPI.ExecuteRule
+    | RulesAPI.ForceConnectionCloseRule
+    | RulesetGetResponse.RulesetsJSChallengeRule
+    | RulesAPI.LogRule
+    | RulesAPI.LogCustomFieldRule
+    | RulesAPI.ManagedChallengeRule
+    | RulesAPI.RedirectRule
+    | RulesAPI.RewriteRule
+    | RulesAPI.RouteRule
+    | RulesAPI.ScoreRule
+    | RulesAPI.ServeErrorRule
+    | RulesAPI.SetCacheSettingsRule
+    | RulesAPI.SetConfigRule
+    | RulesAPI.SkipRule
+  >;
+
+  /**
+   * The version of the ruleset.
+   */
+  version: string;
+
+  /**
+   * An informative description of the ruleset.
+   */
+  description?: string;
+}
+
+export namespace RulesetGetResponse {
+  export interface RulesetsChallengeRule {
+    /**
+     * The timestamp of when the rule was last modified.
+     */
+    last_updated: string;
+
+    /**
+     * The version of the rule.
+     */
+    version: string;
+
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * The categories of the rule.
+     */
+    categories?: Array<string>;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.Logging;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface RulesetsJSChallengeRule {
+    /**
+     * The timestamp of when the rule was last modified.
+     */
+    last_updated: string;
+
+    /**
+     * The version of the rule.
+     */
+    version: string;
+
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'js_challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * The categories of the rule.
+     */
+    categories?: Array<string>;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsJSChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.Logging;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsJSChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsJSChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+}
+
+export interface RulesetCreateParams {
+  /**
+   * Body param: The kind of the ruleset.
+   */
+  kind: KindParam;
+
+  /**
+   * Body param: The human-readable name of the ruleset.
+   */
+  name: string;
+
+  /**
+   * Body param: The phase of the ruleset.
+   */
+  phase: PhaseParam;
+
+  /**
+   * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+   * Zone ID.
+   */
+  account_id?: string;
+
+  /**
+   * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+   * Account ID.
+   */
+  zone_id?: string;
+
+  /**
+   * Body param: An informative description of the ruleset.
+   */
+  description?: string;
+
+  /**
+   * Body param: The list of rules in the ruleset.
+   */
+  rules?: Array<
+    | RulesAPI.BlockRuleParam
+    | RulesetCreateParams.RulesetsChallengeRule
+    | RulesAPI.CompressResponseRuleParam
+    | RulesAPI.DDoSDynamicRuleParam
+    | RulesAPI.ExecuteRuleParam
+    | RulesAPI.ForceConnectionCloseRuleParam
+    | RulesetCreateParams.RulesetsJSChallengeRule
+    | RulesAPI.LogRuleParam
+    | RulesAPI.LogCustomFieldRuleParam
+    | RulesAPI.ManagedChallengeRuleParam
+    | RulesAPI.RedirectRuleParam
+    | RulesAPI.RewriteRuleParam
+    | RulesAPI.RouteRuleParam
+    | RulesAPI.ScoreRuleParam
+    | RulesAPI.ServeErrorRuleParam
+    | RulesAPI.SetCacheSettingsRuleParam
+    | RulesAPI.SetConfigRuleParam
+    | RulesAPI.SkipRuleParam
+  >;
+}
+
+export namespace RulesetCreateParams {
+  export interface RulesetsChallengeRule {
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.LoggingParam;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface RulesetsJSChallengeRule {
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'js_challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsJSChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.LoggingParam;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsJSChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsJSChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+}
+
+export interface RulesetUpdateParams {
+  /**
+   * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+   * Zone ID.
+   */
+  account_id?: string;
+
+  /**
+   * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+   * Account ID.
+   */
+  zone_id?: string;
+
+  /**
+   * Body param: An informative description of the ruleset.
+   */
+  description?: string;
+
+  /**
+   * Body param: The kind of the ruleset.
+   */
+  kind?: KindParam;
+
+  /**
+   * Body param: The human-readable name of the ruleset.
+   */
+  name?: string;
+
+  /**
+   * Body param: The phase of the ruleset.
+   */
+  phase?: PhaseParam;
+
+  /**
+   * Body param: The list of rules in the ruleset.
+   */
+  rules?: Array<
+    | RulesAPI.BlockRuleParam
+    | RulesetUpdateParams.RulesetsChallengeRule
+    | RulesAPI.CompressResponseRuleParam
+    | RulesAPI.DDoSDynamicRuleParam
+    | RulesAPI.ExecuteRuleParam
+    | RulesAPI.ForceConnectionCloseRuleParam
+    | RulesetUpdateParams.RulesetsJSChallengeRule
+    | RulesAPI.LogRuleParam
+    | RulesAPI.LogCustomFieldRuleParam
+    | RulesAPI.ManagedChallengeRuleParam
+    | RulesAPI.RedirectRuleParam
+    | RulesAPI.RewriteRuleParam
+    | RulesAPI.RouteRuleParam
+    | RulesAPI.ScoreRuleParam
+    | RulesAPI.ServeErrorRuleParam
+    | RulesAPI.SetCacheSettingsRuleParam
+    | RulesAPI.SetConfigRuleParam
+    | RulesAPI.SkipRuleParam
+  >;
+}
+
+export namespace RulesetUpdateParams {
+  export interface RulesetsChallengeRule {
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.LoggingParam;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface RulesetsJSChallengeRule {
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'js_challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsJSChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.LoggingParam;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsJSChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsJSChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+}
+
+export interface RulesetListParams extends CursorPaginationParams {
+  /**
+   * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+   * Zone ID.
+   */
+  account_id?: string;
+
+  /**
+   * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+   * Account ID.
+   */
+  zone_id?: string;
+}
+
+export interface RulesetDeleteParams {
+  /**
+   * The Account ID to use for this endpoint. Mutually exclusive with the Zone ID.
+   */
+  account_id?: string;
+
+  /**
+   * The Zone ID to use for this endpoint. Mutually exclusive with the Account ID.
+   */
+  zone_id?: string;
+}
+
+export interface RulesetGetParams {
+  /**
+   * The Account ID to use for this endpoint. Mutually exclusive with the Zone ID.
+   */
+  account_id?: string;
+
+  /**
+   * The Zone ID to use for this endpoint. Mutually exclusive with the Account ID.
+   */
+  zone_id?: string;
+}
+
+Rulesets.RulesetListResponsesCursorPagination = RulesetListResponsesCursorPagination;
 Rulesets.Phases = Phases;
 Rulesets.Rules = Rules;
 Rulesets.Versions = Versions;
+Rulesets.VersionListResponsesSinglePage = VersionListResponsesSinglePage;
 
 export declare namespace Rulesets {
-  export { type Kind as Kind, type Phase as Phase, type Ruleset as Ruleset };
+  export {
+    type Kind as Kind,
+    type Phase as Phase,
+    type Ruleset as Ruleset,
+    type RulesetCreateResponse as RulesetCreateResponse,
+    type RulesetUpdateResponse as RulesetUpdateResponse,
+    type RulesetListResponse as RulesetListResponse,
+    type RulesetGetResponse as RulesetGetResponse,
+    RulesetListResponsesCursorPagination as RulesetListResponsesCursorPagination,
+    type RulesetCreateParams as RulesetCreateParams,
+    type RulesetUpdateParams as RulesetUpdateParams,
+    type RulesetListParams as RulesetListParams,
+    type RulesetDeleteParams as RulesetDeleteParams,
+    type RulesetGetParams as RulesetGetParams,
+  };
 
-  export { Phases as Phases };
+  export {
+    Phases as Phases,
+    type PhaseUpdateResponse as PhaseUpdateResponse,
+    type PhaseGetResponse as PhaseGetResponse,
+    type PhaseUpdateParams as PhaseUpdateParams,
+    type PhaseGetParams as PhaseGetParams,
+  };
 
   export {
     Rules as Rules,
@@ -127,7 +2122,21 @@ export declare namespace Rulesets {
     type SetCacheSettingsRule as SetCacheSettingsRule,
     type SetConfigRule as SetConfigRule,
     type SkipRule as SkipRule,
+    type RuleCreateResponse as RuleCreateResponse,
+    type RuleDeleteResponse as RuleDeleteResponse,
+    type RuleEditResponse as RuleEditResponse,
+    type RuleCreateParams as RuleCreateParams,
+    type RuleDeleteParams as RuleDeleteParams,
+    type RuleEditParams as RuleEditParams,
   };
 
-  export { Versions as Versions };
+  export {
+    Versions as Versions,
+    type VersionListResponse as VersionListResponse,
+    type VersionGetResponse as VersionGetResponse,
+    VersionListResponsesSinglePage as VersionListResponsesSinglePage,
+    type VersionListParams as VersionListParams,
+    type VersionDeleteParams as VersionDeleteParams,
+    type VersionGetParams as VersionGetParams,
+  };
 }

--- a/src/resources/rulesets/versions.ts
+++ b/src/resources/rulesets/versions.ts
@@ -1,5 +1,601 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../resource';
+import { isRequestOptions } from '../../core';
+import * as Core from '../../core';
+import * as RulesAPI from './rules';
+import * as RulesetsAPI from './rulesets';
+import { CloudflareError } from '../../error';
+import { SinglePage } from '../../pagination';
 
-export class Versions extends APIResource {}
+export class Versions extends APIResource {
+  /**
+   * Fetches the versions of an account or zone ruleset.
+   *
+   * @example
+   * ```ts
+   * // Automatically fetches more pages as needed.
+   * for await (const versionListResponse of client.rulesets.versions.list(
+   *   '2f2feab2026849078ba485f918791bdc',
+   *   { account_id: 'account_id' },
+   * )) {
+   *   // ...
+   * }
+   * ```
+   */
+  list(
+    rulesetId: string,
+    params?: VersionListParams,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<VersionListResponsesSinglePage, VersionListResponse>;
+  list(
+    rulesetId: string,
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<VersionListResponsesSinglePage, VersionListResponse>;
+  list(
+    rulesetId: string,
+    params: VersionListParams | Core.RequestOptions = {},
+    options?: Core.RequestOptions,
+  ): Core.PagePromise<VersionListResponsesSinglePage, VersionListResponse> {
+    if (isRequestOptions(params)) {
+      return this.list(rulesetId, {}, params);
+    }
+    const { account_id, zone_id } = params;
+    if (!account_id && !zone_id) {
+      throw new CloudflareError('You must provide either account_id or zone_id.');
+    }
+    if (account_id && zone_id) {
+      throw new CloudflareError('You cannot provide both account_id and zone_id.');
+    }
+    const { accountOrZone, accountOrZoneId } =
+      account_id ?
+        {
+          accountOrZone: 'accounts',
+          accountOrZoneId: account_id,
+        }
+      : {
+          accountOrZone: 'zones',
+          accountOrZoneId: zone_id,
+        };
+    return this._client.getAPIList(
+      `/${accountOrZone}/${accountOrZoneId}/rulesets/${rulesetId}/versions`,
+      VersionListResponsesSinglePage,
+      options,
+    );
+  }
+
+  /**
+   * Deletes an existing version of an account or zone ruleset.
+   *
+   * @example
+   * ```ts
+   * await client.rulesets.versions.delete(
+   *   '2f2feab2026849078ba485f918791bdc',
+   *   '1',
+   *   { account_id: 'account_id' },
+   * );
+   * ```
+   */
+  delete(
+    rulesetId: string,
+    rulesetVersion: string,
+    params?: VersionDeleteParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<void>;
+  delete(rulesetId: string, rulesetVersion: string, options?: Core.RequestOptions): Core.APIPromise<void>;
+  delete(
+    rulesetId: string,
+    rulesetVersion: string,
+    params: VersionDeleteParams | Core.RequestOptions = {},
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<void> {
+    if (isRequestOptions(params)) {
+      return this.delete(rulesetId, rulesetVersion, {}, params);
+    }
+    const { account_id, zone_id } = params;
+    if (!account_id && !zone_id) {
+      throw new CloudflareError('You must provide either account_id or zone_id.');
+    }
+    if (account_id && zone_id) {
+      throw new CloudflareError('You cannot provide both account_id and zone_id.');
+    }
+    const { accountOrZone, accountOrZoneId } =
+      account_id ?
+        {
+          accountOrZone: 'accounts',
+          accountOrZoneId: account_id,
+        }
+      : {
+          accountOrZone: 'zones',
+          accountOrZoneId: zone_id,
+        };
+    return this._client.delete(
+      `/${accountOrZone}/${accountOrZoneId}/rulesets/${rulesetId}/versions/${rulesetVersion}`,
+      { ...options, headers: { Accept: '*/*', ...options?.headers } },
+    );
+  }
+
+  /**
+   * Fetches a specific version of an account or zone ruleset.
+   *
+   * @example
+   * ```ts
+   * const version = await client.rulesets.versions.get(
+   *   '2f2feab2026849078ba485f918791bdc',
+   *   '1',
+   *   { account_id: 'account_id' },
+   * );
+   * ```
+   */
+  get(
+    rulesetId: string,
+    rulesetVersion: string,
+    params?: VersionGetParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<VersionGetResponse>;
+  get(
+    rulesetId: string,
+    rulesetVersion: string,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<VersionGetResponse>;
+  get(
+    rulesetId: string,
+    rulesetVersion: string,
+    params: VersionGetParams | Core.RequestOptions = {},
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<VersionGetResponse> {
+    if (isRequestOptions(params)) {
+      return this.get(rulesetId, rulesetVersion, {}, params);
+    }
+    const { account_id, zone_id } = params;
+    if (!account_id && !zone_id) {
+      throw new CloudflareError('You must provide either account_id or zone_id.');
+    }
+    if (account_id && zone_id) {
+      throw new CloudflareError('You cannot provide both account_id and zone_id.');
+    }
+    const { accountOrZone, accountOrZoneId } =
+      account_id ?
+        {
+          accountOrZone: 'accounts',
+          accountOrZoneId: account_id,
+        }
+      : {
+          accountOrZone: 'zones',
+          accountOrZoneId: zone_id,
+        };
+    return (
+      this._client.get(
+        `/${accountOrZone}/${accountOrZoneId}/rulesets/${rulesetId}/versions/${rulesetVersion}`,
+        options,
+      ) as Core.APIPromise<{ result: VersionGetResponse }>
+    )._thenUnwrap((obj) => obj.result);
+  }
+}
+
+export class VersionListResponsesSinglePage extends SinglePage<VersionListResponse> {}
+
+/**
+ * A ruleset object.
+ */
+export interface VersionListResponse {
+  /**
+   * The unique ID of the ruleset.
+   */
+  id: string;
+
+  /**
+   * The kind of the ruleset.
+   */
+  kind: RulesetsAPI.Kind;
+
+  /**
+   * The timestamp of when the ruleset was last modified.
+   */
+  last_updated: string;
+
+  /**
+   * The human-readable name of the ruleset.
+   */
+  name: string;
+
+  /**
+   * The phase of the ruleset.
+   */
+  phase: RulesetsAPI.Phase;
+
+  /**
+   * The version of the ruleset.
+   */
+  version: string;
+
+  /**
+   * An informative description of the ruleset.
+   */
+  description?: string;
+}
+
+/**
+ * A ruleset object.
+ */
+export interface VersionGetResponse {
+  /**
+   * The unique ID of the ruleset.
+   */
+  id: string;
+
+  /**
+   * The kind of the ruleset.
+   */
+  kind: RulesetsAPI.Kind;
+
+  /**
+   * The timestamp of when the ruleset was last modified.
+   */
+  last_updated: string;
+
+  /**
+   * The human-readable name of the ruleset.
+   */
+  name: string;
+
+  /**
+   * The phase of the ruleset.
+   */
+  phase: RulesetsAPI.Phase;
+
+  /**
+   * The list of rules in the ruleset.
+   */
+  rules: Array<
+    | RulesAPI.BlockRule
+    | VersionGetResponse.RulesetsChallengeRule
+    | RulesAPI.CompressResponseRule
+    | RulesAPI.DDoSDynamicRule
+    | RulesAPI.ExecuteRule
+    | RulesAPI.ForceConnectionCloseRule
+    | VersionGetResponse.RulesetsJSChallengeRule
+    | RulesAPI.LogRule
+    | RulesAPI.LogCustomFieldRule
+    | RulesAPI.ManagedChallengeRule
+    | RulesAPI.RedirectRule
+    | RulesAPI.RewriteRule
+    | RulesAPI.RouteRule
+    | RulesAPI.ScoreRule
+    | RulesAPI.ServeErrorRule
+    | RulesAPI.SetCacheSettingsRule
+    | RulesAPI.SetConfigRule
+    | RulesAPI.SkipRule
+  >;
+
+  /**
+   * The version of the ruleset.
+   */
+  version: string;
+
+  /**
+   * An informative description of the ruleset.
+   */
+  description?: string;
+}
+
+export namespace VersionGetResponse {
+  export interface RulesetsChallengeRule {
+    /**
+     * The timestamp of when the rule was last modified.
+     */
+    last_updated: string;
+
+    /**
+     * The version of the rule.
+     */
+    version: string;
+
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * The categories of the rule.
+     */
+    categories?: Array<string>;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.Logging;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+
+  export interface RulesetsJSChallengeRule {
+    /**
+     * The timestamp of when the rule was last modified.
+     */
+    last_updated: string;
+
+    /**
+     * The version of the rule.
+     */
+    version: string;
+
+    /**
+     * The unique ID of the rule.
+     */
+    id?: string;
+
+    /**
+     * The action to perform when the rule matches.
+     */
+    action?: 'js_challenge';
+
+    /**
+     * The parameters configuring the rule's action.
+     */
+    action_parameters?: unknown;
+
+    /**
+     * The categories of the rule.
+     */
+    categories?: Array<string>;
+
+    /**
+     * An informative description of the rule.
+     */
+    description?: string;
+
+    /**
+     * Whether the rule should be executed.
+     */
+    enabled?: boolean;
+
+    /**
+     * Configuration for exposed credential checking.
+     */
+    exposed_credential_check?: RulesetsJSChallengeRule.ExposedCredentialCheck;
+
+    /**
+     * The expression defining which traffic will match the rule.
+     */
+    expression?: string;
+
+    /**
+     * An object configuring the rule's logging behavior.
+     */
+    logging?: RulesAPI.Logging;
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    ratelimit?: RulesetsJSChallengeRule.Ratelimit;
+
+    /**
+     * The reference of the rule (the rule's ID by default).
+     */
+    ref?: string;
+  }
+
+  export namespace RulesetsJSChallengeRule {
+    /**
+     * Configuration for exposed credential checking.
+     */
+    export interface ExposedCredentialCheck {
+      /**
+       * An expression that selects the password used in the credentials check.
+       */
+      password_expression: string;
+
+      /**
+       * An expression that selects the user ID used in the credentials check.
+       */
+      username_expression: string;
+    }
+
+    /**
+     * An object configuring the rule's rate limit behavior.
+     */
+    export interface Ratelimit {
+      /**
+       * Characteristics of the request on which the rate limit counter will be
+       * incremented.
+       */
+      characteristics: Array<string>;
+
+      /**
+       * Period in seconds over which the counter is being incremented.
+       */
+      period: number;
+
+      /**
+       * An expression that defines when the rate limit counter should be incremented. It
+       * defaults to the same as the rule's expression.
+       */
+      counting_expression?: string;
+
+      /**
+       * Period of time in seconds after which the action will be disabled following its
+       * first execution.
+       */
+      mitigation_timeout?: number;
+
+      /**
+       * The threshold of requests per period after which the action will be executed for
+       * the first time.
+       */
+      requests_per_period?: number;
+
+      /**
+       * Whether counting is only performed when an origin is reached.
+       */
+      requests_to_origin?: boolean;
+
+      /**
+       * The score threshold per period for which the action will be executed the first
+       * time.
+       */
+      score_per_period?: number;
+
+      /**
+       * A response header name provided by the origin, which contains the score to
+       * increment rate limit counter with.
+       */
+      score_response_header_name?: string;
+    }
+  }
+}
+
+export interface VersionListParams {
+  /**
+   * The Account ID to use for this endpoint. Mutually exclusive with the Zone ID.
+   */
+  account_id?: string;
+
+  /**
+   * The Zone ID to use for this endpoint. Mutually exclusive with the Account ID.
+   */
+  zone_id?: string;
+}
+
+export interface VersionDeleteParams {
+  /**
+   * The Account ID to use for this endpoint. Mutually exclusive with the Zone ID.
+   */
+  account_id?: string;
+
+  /**
+   * The Zone ID to use for this endpoint. Mutually exclusive with the Account ID.
+   */
+  zone_id?: string;
+}
+
+export interface VersionGetParams {
+  /**
+   * The Account ID to use for this endpoint. Mutually exclusive with the Zone ID.
+   */
+  account_id?: string;
+
+  /**
+   * The Zone ID to use for this endpoint. Mutually exclusive with the Account ID.
+   */
+  zone_id?: string;
+}
+
+Versions.VersionListResponsesSinglePage = VersionListResponsesSinglePage;
+
+export declare namespace Versions {
+  export {
+    type VersionListResponse as VersionListResponse,
+    type VersionGetResponse as VersionGetResponse,
+    VersionListResponsesSinglePage as VersionListResponsesSinglePage,
+    type VersionListParams as VersionListParams,
+    type VersionDeleteParams as VersionDeleteParams,
+    type VersionGetParams as VersionGetParams,
+  };
+}

--- a/tests/api-resources/rulesets/phases/versions.test.ts
+++ b/tests/api-resources/rulesets/phases/versions.test.ts
@@ -1,0 +1,40 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+import Cloudflare from 'cloudflare';
+import { Response } from 'node-fetch';
+
+const client = new Cloudflare({
+  apiKey: '144c9defac04969c7bfad8efaa8ea194',
+  apiEmail: 'user@example.com',
+  baseURL: process.env['TEST_API_BASE_URL'] ?? 'http://127.0.0.1:4010',
+});
+
+describe('resource versions', () => {
+  // TODO: investigate broken test
+  test.skip('list', async () => {
+    const responsePromise = client.rulesets.phases.versions.list('http_request_firewall_custom', {
+      account_id: 'account_id',
+    });
+    const rawResponse = await responsePromise.asResponse();
+    expect(rawResponse).toBeInstanceOf(Response);
+    const response = await responsePromise;
+    expect(response).not.toBeInstanceOf(Response);
+    const dataAndResponse = await responsePromise.withResponse();
+    expect(dataAndResponse.data).toBe(response);
+    expect(dataAndResponse.response).toBe(rawResponse);
+  });
+
+  // TODO: investigate broken test
+  test.skip('get', async () => {
+    const responsePromise = client.rulesets.phases.versions.get('http_request_firewall_custom', '1', {
+      account_id: 'account_id',
+    });
+    const rawResponse = await responsePromise.asResponse();
+    expect(rawResponse).toBeInstanceOf(Response);
+    const response = await responsePromise;
+    expect(response).not.toBeInstanceOf(Response);
+    const dataAndResponse = await responsePromise.withResponse();
+    expect(dataAndResponse.data).toBe(response);
+    expect(dataAndResponse.response).toBe(rawResponse);
+  });
+});


### PR DESCRIPTION
## Summary

- Restores the full `rulesets` API surface that was erroneously stripped in a recent codegen update
- Reverts changes to `rulesets`, `rulesets.phases`, `rulesets.phases.versions`, `rulesets.rules`, and `rulesets.versions` sub-resources
- Restores all removed methods (`create`, `update`, `list`, `delete`, `get`, `edit`), response types, and params
- Re-adds the deleted `rulesets/phases/versions.test.ts` test file

## What happened

A codegen update gutted the rulesets resource files, removing all methods, response types, and parameter types while leaving behind empty structural shells. This PR restores the complete rulesets implementation from `v6.0.0-beta.1`.

## Files changed

- `api.md` -- restored rulesets section with methods and types
- `src/resources/rulesets/rulesets.ts` -- restored CRUD methods and response types
- `src/resources/rulesets/phases/phases.ts` -- restored `update()` and `get()` methods
- `src/resources/rulesets/phases/versions.ts` -- restored `list()` and `get()` methods
- `src/resources/rulesets/rules.ts` -- restored `create()`, `delete()`, `edit()` methods
- `src/resources/rulesets/versions.ts` -- restored `list()`, `delete()`, `get()` methods
- `src/resources/rulesets/index.ts` -- restored type exports
- `src/resources/rulesets/phases/index.ts` -- restored type exports
- `tests/api-resources/rulesets/phases/versions.test.ts` -- restored deleted test