### PR TITLE
fix: resolve type errors from codegen overwriting manual fixes

### DIFF
--- a/src/resources/ai/ai.ts
+++ b/src/resources/ai/ai.ts
@@ -14,7 +14,6 @@ import {
   ToMarkdownSupportedResponsesSinglePage,
   ToMarkdownTransformParams,
   ToMarkdownTransformResponse,
-  ToMarkdownTransformResponsesSinglePage,
 } from './to-markdown';
 import * as FinetunesAPI from './finetunes/finetunes';
 import {
@@ -1114,7 +1113,6 @@ AI.Models = Models;
 AI.ModelListResponsesV4PagePaginationArray = ModelListResponsesV4PagePaginationArray;
 AI.ToMarkdown = ToMarkdown;
 AI.ToMarkdownSupportedResponsesSinglePage = ToMarkdownSupportedResponsesSinglePage;
-AI.ToMarkdownTransformResponsesSinglePage = ToMarkdownTransformResponsesSinglePage;
 
 export declare namespace AI {
   export { type AIRunResponse as AIRunResponse, type AIRunParams as AIRunParams };
@@ -1153,7 +1151,6 @@ export declare namespace AI {
     type ToMarkdownSupportedResponse as ToMarkdownSupportedResponse,
     type ToMarkdownTransformResponse as ToMarkdownTransformResponse,
     ToMarkdownSupportedResponsesSinglePage as ToMarkdownSupportedResponsesSinglePage,
-    ToMarkdownTransformResponsesSinglePage as ToMarkdownTransformResponsesSinglePage,
     type ToMarkdownSupportedParams as ToMarkdownSupportedParams,
     type ToMarkdownTransformParams as ToMarkdownTransformParams,
   };

--- a/src/resources/ai/index.ts
+++ b/src/resources/ai/index.ts
@@ -23,7 +23,6 @@ export {
 export { TaskListResponsesSinglePage, Tasks, type TaskListResponse, type TaskListParams } from './tasks';
 export {
   ToMarkdownSupportedResponsesSinglePage,
-  ToMarkdownTransformResponsesSinglePage,
   ToMarkdown,
   type ToMarkdownSupportedResponse,
   type ToMarkdownTransformResponse,

--- a/src/resources/ai/to-markdown.ts
+++ b/src/resources/ai/to-markdown.ts
@@ -26,19 +26,18 @@ export class ToMarkdown extends APIResource {
   transform(
     params: ToMarkdownTransformParams,
     options?: Core.RequestOptions,
-  ): Core.PagePromise<ToMarkdownTransformResponsesSinglePage, ToMarkdownTransformResponse> {
+  ): Core.APIPromise<ToMarkdownTransformResponse[]> {
     const { account_id, file } = params;
-    return this._client.getAPIList(
-      `/accounts/${account_id}/ai/tomarkdown`,
-      ToMarkdownTransformResponsesSinglePage,
-      Core.multipartFormRequestOptions({ body: file, method: 'post', ...options }),
-    );
+    return (
+      this._client.post(
+        `/accounts/${account_id}/ai/tomarkdown`,
+        Core.multipartFormRequestOptions({ body: file, ...options }),
+      ) as Core.APIPromise<{ result: ToMarkdownTransformResponse[] }>
+    )._thenUnwrap((obj) => obj.result);
   }
 }
 
 export class ToMarkdownSupportedResponsesSinglePage extends SinglePage<ToMarkdownSupportedResponse> {}
-
-export class ToMarkdownTransformResponsesSinglePage extends SinglePage<ToMarkdownTransformResponse> {}
 
 export interface ToMarkdownSupportedResponse {
   extension: string;
@@ -81,14 +80,12 @@ export namespace ToMarkdownTransformParams {
 }
 
 ToMarkdown.ToMarkdownSupportedResponsesSinglePage = ToMarkdownSupportedResponsesSinglePage;
-ToMarkdown.ToMarkdownTransformResponsesSinglePage = ToMarkdownTransformResponsesSinglePage;
 
 export declare namespace ToMarkdown {
   export {
     type ToMarkdownSupportedResponse as ToMarkdownSupportedResponse,
     type ToMarkdownTransformResponse as ToMarkdownTransformResponse,
     ToMarkdownSupportedResponsesSinglePage as ToMarkdownSupportedResponsesSinglePage,
-    ToMarkdownTransformResponsesSinglePage as ToMarkdownTransformResponsesSinglePage,
     type ToMarkdownSupportedParams as ToMarkdownSupportedParams,
     type ToMarkdownTransformParams as ToMarkdownTransformParams,
   };

--- a/src/resources/organizations/organization-profile.ts
+++ b/src/resources/organizations/organization-profile.ts
@@ -24,13 +24,10 @@ export class OrganizationProfileResource extends APIResource {
    * Get an organizations profile if it exists. (Currently in Closed Beta - see
    * https://developers.cloudflare.com/fundamentals/organizations/)
    */
-  get(
-    organizationId: string,
-    options?: Core.RequestOptions,
-  ): Core.APIPromise<organizations_api_ProfileResponse.Result> {
+  get(organizationId: string, options?: Core.RequestOptions): Core.APIPromise<OrganizationProfile> {
     return (
       this._client.get(`/organizations/${organizationId}/profile`, options) as Core.APIPromise<{
-        result: organizations_api_ProfileResponse.Result;
+        result: OrganizationProfile;
       }>
     )._thenUnwrap((obj) => obj.result);
   }

--- a/src/resources/radar/ai/to-markdown.ts
+++ b/src/resources/radar/ai/to-markdown.ts
@@ -2,7 +2,6 @@
 
 import { APIResource } from '../../../resource';
 import * as Core from '../../../core';
-import { SinglePage } from '../../../pagination';
 
 export class ToMarkdown extends APIResource {
   /**
@@ -13,17 +12,16 @@ export class ToMarkdown extends APIResource {
   create(
     params: ToMarkdownCreateParams,
     options?: Core.RequestOptions,
-  ): Core.PagePromise<ToMarkdownCreateResponsesSinglePage, ToMarkdownCreateResponse> {
+  ): Core.APIPromise<ToMarkdownCreateResponse[]> {
     const { account_id, ...body } = params;
-    return this._client.getAPIList(
-      `/accounts/${account_id}/ai/tomarkdown`,
-      ToMarkdownCreateResponsesSinglePage,
-      Core.multipartFormRequestOptions({ body, method: 'post', ...options }),
-    );
+    return (
+      this._client.post(
+        `/accounts/${account_id}/ai/tomarkdown`,
+        Core.multipartFormRequestOptions({ body, ...options }),
+      ) as Core.APIPromise<{ result: ToMarkdownCreateResponse[] }>
+    )._thenUnwrap((obj) => obj.result);
   }
 }
-
-export class ToMarkdownCreateResponsesSinglePage extends SinglePage<ToMarkdownCreateResponse> {}
 
 export interface ToMarkdownCreateResponse {
   data: string;
@@ -49,12 +47,9 @@ export interface ToMarkdownCreateParams {
   files: Array<Core.Uploadable>;
 }
 
-ToMarkdown.ToMarkdownCreateResponsesSinglePage = ToMarkdownCreateResponsesSinglePage;
-
 export declare namespace ToMarkdown {
   export {
     type ToMarkdownCreateResponse as ToMarkdownCreateResponse,
-    ToMarkdownCreateResponsesSinglePage as ToMarkdownCreateResponsesSinglePage,
     type ToMarkdownCreateParams as ToMarkdownCreateParams,
   };
 }


### PR DESCRIPTION
## Summary

- **ai/to-markdown, radar/ai/to-markdown**: `getAPIList()` does not accept async options, but `multipartFormRequestOptions()` returns `Promise<RequestOptions>`. Switch to `post()` + `_thenUnwrap()` since these endpoints use `SinglePage` which is not actually paginated. Remove unused `SinglePage` wrapper classes and re-exports.
- **organizations/organization-profile**: codegen emits `organizations_api_ProfileResponse.Result` which is an undefined namespace. Replace with the locally-defined `OrganizationProfile` interface.

## Context

All three issues are manual fixes that were previously applied (`cf0ad2683`, `d84ea7709`) and overwritten by the `b2da5c331` codegen run ("feat(api): api update", 2026-04-19).

## Validation

```
tsc --noEmit   -> 0 errors (was 4)
eslint         -> 0 errors
```