### PR TITLE
ci: set semgrep timeout to 25m, enable breaking change detection

### DIFF
--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -9,9 +9,6 @@ jobs:
   detect_breaking_changes:
     runs-on: 'ubuntu-latest'
     name: detect-breaking-changes
-    # Temporarily disabled: major version bump in progress — breaking changes are expected.
-    # Re-enable once the v<next> release is cut.
-    if: false
     steps:
       - name: Calculate fetch-depth
         run: |

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -15,6 +15,7 @@ jobs:
   semgrep:
     name: semgrep-oss
     runs-on: ubuntu-slim
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
## Summary

- Adds `timeout-minutes: 25` to the semgrep workflow
- Re-enables the `detect-breaking-changes` workflow by removing `if: false`