### PR TITLE
ci(detect-breaking-changes): per-job contents: read

### DIFF
--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   detect_breaking_changes:
+    permissions:
+      contents: read
     runs-on: 'ubuntu-latest'
     name: detect-breaking-changes
     # Temporarily disabled: major version bump in progress — breaking changes are expected.


### PR DESCRIPTION
Adds `permissions: contents: read` to the `detect_breaking_changes` job. The job is currently `if: false` gated, but when re-enabled it only diff-checks the PR head against the base SHA — no need for any write scopes on `GITHUB_TOKEN`.

Matches the per-job permission style already used in `ci.yml` (also `contents: read`). YAML validated locally.