### PR TITLE
Sync staged changes (curated) - 2026-05-13

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 2224
 openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/cloudflare%2Fcloudflare-a6c352830d1270d0abb5bb983058ea21815e1bb7d2e163965335dcb0e706f057.yml
-openapi_spec_hash: 31da2976a230d6a4056b11bbe236f35b
+openapi_spec_hash: 318e54e5c7666a55fb803495fa7e383c
 config_hash: a0d2c4abe971a3caafcc4324d98d7106

--- a/src/resources/email-security/investigate/investigate.ts
+++ b/src/resources/email-security/investigate/investigate.ts
@@ -205,6 +205,10 @@ export interface InvestigateListResponse {
 
   sent_date?: string | null;
 
+  smtp_helo_server_ip?: string | null;
+
+  smtp_previous_hop_ip?: string | null;
+
   subject?: string | null;
 
   threat_categories?: Array<string> | null;
@@ -214,6 +218,8 @@ export interface InvestigateListResponse {
   to_name?: Array<string> | null;
 
   validation?: InvestigateListResponse.Validation;
+
+  x_originating_ip?: string | null;
 }
 
 export namespace InvestigateListResponse {
@@ -459,6 +465,10 @@ export interface InvestigateGetResponse {
 
   sent_date?: string | null;
 
+  smtp_helo_server_ip?: string | null;
+
+  smtp_previous_hop_ip?: string | null;
+
   subject?: string | null;
 
   threat_categories?: Array<string> | null;
@@ -468,6 +478,8 @@ export interface InvestigateGetResponse {
   to_name?: Array<string> | null;
 
   validation?: InvestigateGetResponse.Validation;
+
+  x_originating_ip?: string | null;
 }
 
 export namespace InvestigateGetResponse {
@@ -625,6 +637,11 @@ export interface InvestigateListParams extends V4PagePaginationArrayParams {
    * Query param
    */
   cursor?: string;
+
+  /**
+   * Query param: Delivery status to filter by.
+   */
+  delivery_status?: 'delivered' | 'moved' | 'quarantined' | 'rejected' | 'deferred' | 'bounced' | 'queued';
 
   /**
    * Query param: Whether to include only detections in search results.

--- a/src/resources/radar/http/http.ts
+++ b/src/resources/radar/http/http.ts
@@ -80,6 +80,7 @@ export class HTTP extends APIResource {
   summaryV2(
     dimension:
       | 'ADM1'
+      | 'API_TRAFFIC'
       | 'AS'
       | 'BOT_CLASS'
       | 'BROWSER'
@@ -98,6 +99,7 @@ export class HTTP extends APIResource {
   summaryV2(
     dimension:
       | 'ADM1'
+      | 'API_TRAFFIC'
       | 'AS'
       | 'BOT_CLASS'
       | 'BROWSER'
@@ -115,6 +117,7 @@ export class HTTP extends APIResource {
   summaryV2(
     dimension:
       | 'ADM1'
+      | 'API_TRAFFIC'
       | 'AS'
       | 'BOT_CLASS'
       | 'BROWSER'
@@ -180,6 +183,7 @@ export class HTTP extends APIResource {
   timeseriesGroupsV2(
     dimension:
       | 'ADM1'
+      | 'API_TRAFFIC'
       | 'AS'
       | 'BOT_CLASS'
       | 'BROWSER'
@@ -198,6 +202,7 @@ export class HTTP extends APIResource {
   timeseriesGroupsV2(
     dimension:
       | 'ADM1'
+      | 'API_TRAFFIC'
       | 'AS'
       | 'BOT_CLASS'
       | 'BROWSER'
@@ -215,6 +220,7 @@ export class HTTP extends APIResource {
   timeseriesGroupsV2(
     dimension:
       | 'ADM1'
+      | 'API_TRAFFIC'
       | 'AS'
       | 'BOT_CLASS'
       | 'BROWSER'
@@ -657,6 +663,12 @@ export namespace HTTPTimeseriesGroupsV2Response {
 
 export interface HTTPSummaryV2Params {
   /**
+   * Filters results by API traffic classification. API traffic is identified by JSON
+   * or XML response content types on dynamic (non-cacheable) HTTP requests.
+   */
+  apiTraffic?: Array<'API' | 'NON_API'>;
+
+  /**
    * Filters results by Autonomous System. Specify one or more Autonomous System
    * Numbers (ASNs) as a comma-separated list. Prefix with `-` to exclude ASNs from
    * results. For example, `-174, 3356` excludes results from AS174, but includes
@@ -764,6 +776,12 @@ export interface HTTPTimeseriesParams {
    * [Aggregation intervals](https://developers.cloudflare.com/radar/concepts/aggregation-intervals/).
    */
   aggInterval?: '15m' | '1h' | '1d' | '1w';
+
+  /**
+   * Filters results by API traffic classification. API traffic is identified by JSON
+   * or XML response content types on dynamic (non-cacheable) HTTP requests.
+   */
+  apiTraffic?: Array<'API' | 'NON_API'>;
 
   /**
    * Filters results by Autonomous System. Specify one or more Autonomous System
@@ -877,6 +895,12 @@ export interface HTTPTimeseriesGroupsV2Params {
    * [Aggregation intervals](https://developers.cloudflare.com/radar/concepts/aggregation-intervals/).
    */
   aggInterval?: '15m' | '1h' | '1d' | '1w';
+
+  /**
+   * Filters results by API traffic classification. API traffic is identified by JSON
+   * or XML response content types on dynamic (non-cacheable) HTTP requests.
+   */
+  apiTraffic?: Array<'API' | 'NON_API'>;
 
   /**
    * Filters results by Autonomous System. Specify one or more Autonomous System

--- a/src/resources/radar/post-quantum/tls.ts
+++ b/src/resources/radar/post-quantum/tls.ts
@@ -6,8 +6,9 @@ import * as Core from '../../../core';
 export class TLS extends APIResource {
   /**
    * Tests whether a hostname or IP address supports Post-Quantum (PQ) TLS key
-   * exchange. Returns information about the negotiated key exchange algorithm and
-   * whether it uses PQ cryptography.
+   * exchange. Returns information about the negotiated key exchange algorithm,
+   * whether it uses PQ cryptography, and any detected TLS implementation bugs (Split
+   * ClientHello, HRR failure, etc.).
    *
    * @example
    * ```ts
@@ -26,6 +27,8 @@ export class TLS extends APIResource {
 }
 
 export interface TLSSupportResponse {
+  bugs: TLSSupportResponse.Bugs;
+
   /**
    * The host that was tested
    */
@@ -42,9 +45,35 @@ export interface TLSSupportResponse {
   kexName: string;
 
   /**
-   * Whether the negotiated key exchange uses Post-Quantum cryptography
+   * Whether the negotiated key exchange uses Post-Quantum cryptography (specifically
+   * X25519MLKEM768)
    */
   pq: boolean;
+}
+
+export namespace TLSSupportResponse {
+  export interface Bugs {
+    /**
+     * Server sends a HelloRetryRequest but fails to complete the handshake after the
+     * client sends the second ClientHello. Often caused by non-compliant TLS 1.3
+     * implementations on shared hosting providers.
+     */
+    hrrFailure: boolean;
+
+    /**
+     * Server rejects fragmented ClientHello caused by large PQ keyshare, but accepts
+     * classical (non-PQ) handshakes. Typically caused by middleboxes or firewalls that
+     * cannot reassemble split TLS ClientHello messages.
+     */
+    splitClientHello: boolean;
+
+    /**
+     * Server cannot handle an unknown key exchange algorithm in the ClientHello
+     * keyshare extension. Compliant servers should respond with HelloRetryRequest for
+     * a supported algorithm.
+     */
+    unknownKeyshare: boolean;
+  }
 }
 
 export interface TLSSupportParams {

--- a/src/resources/zones/custom-nameservers.ts
+++ b/src/resources/zones/custom-nameservers.ts
@@ -132,6 +132,11 @@ export namespace CustomNameserverGetResponse {
      * Total results available without any search parameters.
      */
     total_count?: number;
+
+    /**
+     * The number of total pages in the entire result set.
+     */
+    total_pages?: number;
   }
 }
 

--- a/tests/api-resources/email-security/investigate/investigate.test.ts
+++ b/tests/api-resources/email-security/investigate/investigate.test.ts
@@ -29,6 +29,7 @@ describe('resource investigate', () => {
       action_log: true,
       alert_id: 'alert_id',
       cursor: 'cursor',
+      delivery_status: 'delivered',
       detections_only: true,
       domain: 'domain',
       end: '2019-12-27T18:11:19.117Z',

--- a/tests/api-resources/radar/http/http.test.ts
+++ b/tests/api-resources/radar/http/http.test.ts
@@ -34,6 +34,7 @@ describe('resource http', () => {
       client.radar.http.summaryV2(
         'ADM1',
         {
+          apiTraffic: ['API'],
           asn: ['string'],
           botClass: ['LIKELY_AUTOMATED'],
           continent: ['string'],
@@ -81,6 +82,7 @@ describe('resource http', () => {
       client.radar.http.timeseries(
         {
           aggInterval: '1h',
+          apiTraffic: ['API'],
           asn: ['string'],
           botClass: ['LIKELY_AUTOMATED'],
           browserFamily: ['CHROME'],
@@ -130,6 +132,7 @@ describe('resource http', () => {
         'ADM1',
         {
           aggInterval: '1h',
+          apiTraffic: ['API'],
           asn: ['string'],
           botClass: ['LIKELY_AUTOMATED'],
           continent: ['string'],


### PR DESCRIPTION
## Codegen Sync: staging-next -> next

Synced 3 resources from `staging-next` as of 2026-05-13.
1 resource excluded (breaking change).

### Integrated Resources (3)

| Resource | Type | Summary |
|----------|------|---------|
| email-security | chore | update generated types and methods |
| radar | chore | update generated types and methods |
| zones | chore | update generated types and methods |

### Excluded Resources (1)

| Resource | Category | Root Cause |
|----------|----------|------------|
| cache | breaking-change | `originCloudRegions.create`, `.bulkEdit`, `.edit` removed by codegen (detected by `scripts/detect-breaking-changes` against v6.1.0) |

### Shared Changes

- Updated `.stats.yml` codegen metadata

### Validation

| Gate | Result |
|------|--------|
| tsc --noEmit | PASS |
| eslint | PASS |
| Breaking change detection (v6.1.0) | PASS (after cache exclusion) |
| Tests (changed resources) | 131 suites passed, 939 tests passed, 0 failures |