### PR TITLE
ci: restore breaking change detection and semgrep timeout

### DIFF
--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -9,9 +9,6 @@ jobs:
   detect_breaking_changes:
     runs-on: 'ubuntu-latest'
     name: detect-breaking-changes
-    # Temporarily disabled: major version bump in progress — breaking changes are expected.
-    # Re-enable once the v<next> release is cut.
-    if: false
     steps:
       - name: Calculate fetch-depth
         run: |

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -15,6 +15,7 @@ jobs:
   semgrep:
     name: semgrep-oss
     runs-on: ubuntu-slim
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Restores the changes from #2754 that were accidentally overwritten by a codegen sync commit (`abbc1da`).

That sync checked out `.github/workflows/detect-breaking-changes.yml` and `semgrep.yml` from `staging-next`, which still had the `if: false` gate and lacked the `timeout-minutes: 25`.

### Changes

- Remove `if: false` from `detect-breaking-changes` job (re-enables the workflow)
- Add `timeout-minutes: 25` to semgrep job