### PR TITLE
ci: make test and detect-breaking-changes jobs non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
   test:
     timeout-minutes: 10
     name: test
+    continue-on-error: true
     runs-on: ${{ github.repository == 'stainless-sdks/cloudflare-node' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     permissions:

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -9,6 +9,7 @@ jobs:
   detect_breaking_changes:
     runs-on: 'ubuntu-latest'
     name: detect-breaking-changes
+    continue-on-error: true
     steps:
       - name: Calculate fetch-depth
         run: |


### PR DESCRIPTION
## Summary

Make the `test` and `detect-breaking-changes` CI jobs non-blocking by adding `continue-on-error: true`. The jobs still run and report results, but failures no longer fail CI overall.

These jobs are informational for release readiness and should not gate merges on the `next` branch.

## Changes

- `ci.yml`: added `continue-on-error: true` to the `test` job
- `detect-breaking-changes.yml`: added `continue-on-error: true` to the `detect_breaking_changes` job

Refs: [APIX-852](https://jira.cfdata.org/browse/APIX-852)