### PR TITLE
ci: move continue-on-error from job level to step level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
   test:
     timeout-minutes: 10
     name: test
-    continue-on-error: true
     runs-on: ${{ github.repository == 'stainless-sdks/cloudflare-node' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     permissions:
@@ -100,6 +99,7 @@ jobs:
         run: ./scripts/bootstrap
 
       - name: Run tests
+        continue-on-error: true
         run: ./scripts/test
   examples:
     timeout-minutes: 10

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -9,7 +9,6 @@ jobs:
   detect_breaking_changes:
     runs-on: 'ubuntu-latest'
     name: detect-breaking-changes
-    continue-on-error: true
     steps:
       - name: Calculate fetch-depth
         run: |
@@ -29,6 +28,7 @@ jobs:
           yarn install
 
       - name: Detect breaking changes
+        continue-on-error: true
         run: |
           # Try to check out previous versions of the breaking change detection script. This ensures that
           # we still detect breaking changes when entire files and their tests are removed.


### PR DESCRIPTION
## Summary

Move `continue-on-error: true` from the job level to the step level on `test` and `detect-breaking-changes` jobs.

**Why:** Job-level `continue-on-error` prevents the *workflow* from failing but the job itself still reports as failed. If the job is a required status check in branch protection, it still blocks the PR. Step-level `continue-on-error` makes the job conclude as success while the step output still shows the failure details.

## Changes

- `ci.yml`: moved `continue-on-error: true` from `test` job to the "Run tests" step
- `detect-breaking-changes.yml`: moved `continue-on-error: true` from `detect_breaking_changes` job to the "Detect breaking changes" step

Refs: [APIX-852](https://jira.cfdata.org/browse/APIX-852)