### PR TITLE
Sync staged changes (2026-05-19 redo, non-breaking only)

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 2269
 openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/cloudflare%2Fcloudflare-a6c352830d1270d0abb5bb983058ea21815e1bb7d2e163965335dcb0e706f057.yml
-openapi_spec_hash: 8540f176024efef3ee799015ad4a2dd9
+openapi_spec_hash: d440b6377c255296d9fdc0b89e59b511
 config_hash: 86a9b8037b215f0a9c5c69239f9c6cfd

--- a/src/resources/organizations/organization-profile.ts
+++ b/src/resources/organizations/organization-profile.ts
@@ -5,7 +5,7 @@ import * as Core from '../../core';
 
 export class OrganizationProfileResource extends APIResource {
   /**
-   * Modify organization profile. (Currently in Closed Beta - see
+   * Modify organization profile. (Currently in Public Beta - see
    * https://developers.cloudflare.com/fundamentals/organizations/)
    */
   update(
@@ -21,7 +21,7 @@ export class OrganizationProfileResource extends APIResource {
   }
 
   /**
-   * Get an organizations profile if it exists. (Currently in Closed Beta - see
+   * Get an organizations profile if it exists. (Currently in Public Beta - see
    * https://developers.cloudflare.com/fundamentals/organizations/)
    */
   get(organizationId: string, options?: Core.RequestOptions): Core.APIPromise<OrganizationProfile> {

--- a/src/resources/organizations/organizations.ts
+++ b/src/resources/organizations/organizations.ts
@@ -19,7 +19,7 @@ export class Organizations extends APIResource {
   logs: LogsAPI.Logs = new LogsAPI.Logs(this._client);
 
   /**
-   * Create a new organization for a user. (Currently in Closed Beta - see
+   * Create a new organization for a user. (Currently in Public Beta - see
    * https://developers.cloudflare.com/fundamentals/organizations/)
    */
   create(body: OrganizationCreateParams, options?: Core.RequestOptions): Core.APIPromise<Organization> {
@@ -29,7 +29,7 @@ export class Organizations extends APIResource {
   }
 
   /**
-   * Modify organization. (Currently in Closed Beta - see
+   * Modify organization. (Currently in Public Beta - see
    * https://developers.cloudflare.com/fundamentals/organizations/)
    */
   update(
@@ -46,7 +46,7 @@ export class Organizations extends APIResource {
 
   /**
    * Retrieve a list of organizations a particular user has access to. (Currently in
-   * Closed Beta - see https://developers.cloudflare.com/fundamentals/organizations/)
+   * Public Beta - see https://developers.cloudflare.com/fundamentals/organizations/)
    */
   list(
     query?: OrganizationListParams,
@@ -66,7 +66,7 @@ export class Organizations extends APIResource {
   /**
    * Delete an organization. The organization MUST be empty before deleting. It must
    * not contain any sub-organizations, accounts, members or users. (Currently in
-   * Closed Beta - see https://developers.cloudflare.com/fundamentals/organizations/)
+   * Public Beta - see https://developers.cloudflare.com/fundamentals/organizations/)
    */
   delete(organizationId: string, options?: Core.RequestOptions): Core.APIPromise<OrganizationDeleteResponse> {
     return (
@@ -77,7 +77,7 @@ export class Organizations extends APIResource {
   }
 
   /**
-   * Retrieve the details of a certain organization. (Currently in Closed Beta - see
+   * Retrieve the details of a certain organization. (Currently in Public Beta - see
    * https://developers.cloudflare.com/fundamentals/organizations/)
    */
   get(organizationId: string, options?: Core.RequestOptions): Core.APIPromise<Organization> {


### PR DESCRIPTION
## Codegen Sync: staging-next -> next

Synced 1 of 5 changed resources from `staging-next` as of 2026-05-19. The
other 4 are still in the same state that caused them to be deferred from the
previous sync (PR #2768).

Source: `origin/staging-next` @ 2f2d2b4ff
Base:   `origin/next` @ ab07b8b67

### Local Validation (all three gates pass)

| Gate | Command | Result |
|------|---------|--------|
| Type check | `npx tsc --noEmit` | pass |
| Lint | `ESLINT_USE_FLAT_CONFIG=false npx eslint --ext ts,js .` | pass |
| Breaking changes | `./scripts/detect-breaking-changes origin/next` | pass (exit 0) |

### Integrated Resources

| Resource | Type | Summary |
|----------|------|---------|
| organizations | chore | update codegen output |

### Deferred: Breaking Changes (need spec-owner confirmation)

Unchanged from previous sync. Same method renames/removals as before.

| Resource | Change |
|----------|--------|
| api-gateway | `discovery.operations.edit()` removed |
| cache | `originCloudRegions.create` -> `update` (POST -> PUT) |
| cache | `originCloudRegions.bulkEdit` -> `bulkUpdate` |
| cache | `originCloudRegions.edit` removed |

### Deferred: Codegen Regressions

Unchanged from previous sync. Empty resource classes on `staging-next`,
methods exist on `next`, new tests still reference them.

| Resource | Root Cause |
|----------|------------|
| addressing | `RegionalHostnames` and `Regions` classes generated empty |
| billing | `Usage` class generated empty (no `paygo` method) |

### Shared Changes

- `.stats.yml` -- spec hash bump, endpoint count unchanged

Intentionally NOT touched:
- `.github/workflows/*` -- human-owned
- `.release-please-manifest.json`, `CHANGELOG.md`, `package.json`, `src/version.ts` -- release-please-bot owned
- `src/index.ts`, `src/resources/index.ts`, root `api.md` -- no diff in this sync

Tracker: `command-center/.local/sync-typescript-2026-05-19.md` (in devstack)
