### PR TITLE
Sync staged changes (2026-05-20, non-breaking only)

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
-configured_endpoints: 2269
+configured_endpoints: 2272
 openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/cloudflare%2Fcloudflare-a6c352830d1270d0abb5bb983058ea21815e1bb7d2e163965335dcb0e706f057.yml
-openapi_spec_hash: d440b6377c255296d9fdc0b89e59b511
-config_hash: 86a9b8037b215f0a9c5c69239f9c6cfd
+openapi_spec_hash: f60cc2af36bbe305cda4bc0ad0617ff6
+config_hash: 0148d517bb02129e9e259f11db3933eb

--- a/scripts/detect-breaking-changes
+++ b/scripts/detect-breaking-changes
@@ -20,6 +20,8 @@ TEST_PATHS=(
 	tests/api-resources/organizations/organization-profile.test.ts
 	tests/api-resources/organizations/logs/logs.test.ts
 	tests/api-resources/organizations/logs/audit.test.ts
+	tests/api-resources/organizations/billing/billing.test.ts
+	tests/api-resources/organizations/billing/usage.test.ts
 	tests/api-resources/origin-ca-certificates.test.ts
 	tests/api-resources/ips.test.ts
 	tests/api-resources/memberships.test.ts
@@ -279,6 +281,7 @@ TEST_PATHS=(
 	tests/api-resources/audit-logs.test.ts
 	tests/api-resources/billing/billing.test.ts
 	tests/api-resources/billing/profiles.test.ts
+	tests/api-resources/billing/usage.test.ts
 	tests/api-resources/brand-protection/brand-protection.test.ts
 	tests/api-resources/brand-protection/queries.test.ts
 	tests/api-resources/brand-protection/matches.test.ts

--- a/src/resources/organizations/api.md
+++ b/src/resources/organizations/api.md
@@ -35,3 +35,15 @@ Types:
 Methods:
 
 - <code title="get /organizations/{organization_id}/logs/audit">client.organizations.logs.audit.<a href="./src/resources/organizations/logs/audit.ts">list</a>(organizationId, { ...params }) -> AuditListResponsesCursorPaginationAfter</code>
+
+## Billing
+
+### Usage
+
+Types:
+
+- <code><a href="./src/resources/organizations/billing/usage.ts">UsageGetResponse</a></code>
+
+Methods:
+
+- <code title="get /organizations/{organization_id}/billable/usage">client.organizations.billing.usage.<a href="./src/resources/organizations/billing/usage.ts">get</a>(organizationId, { ...params }) -> UsageGetResponse</code>

--- a/src/resources/organizations/billing.ts
+++ b/src/resources/organizations/billing.ts
@@ -1,0 +1,3 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+export * from './billing/index';

--- a/src/resources/organizations/billing/billing.ts
+++ b/src/resources/organizations/billing/billing.ts
@@ -1,0 +1,15 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+import { APIResource } from '../../../resource';
+import * as UsageAPI from './usage';
+import { Usage, UsageGetParams, UsageGetResponse } from './usage';
+
+export class Billing extends APIResource {
+  usage: UsageAPI.Usage = new UsageAPI.Usage(this._client);
+}
+
+Billing.Usage = Usage;
+
+export declare namespace Billing {
+  export { Usage as Usage, type UsageGetResponse as UsageGetResponse, type UsageGetParams as UsageGetParams };
+}

--- a/src/resources/organizations/billing/index.ts
+++ b/src/resources/organizations/billing/index.ts
@@ -1,0 +1,4 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+export { Billing } from './billing';
+export { Usage, type UsageGetResponse, type UsageGetParams } from './usage';

--- a/src/resources/organizations/billing/usage.ts
+++ b/src/resources/organizations/billing/usage.ts
@@ -1,0 +1,270 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+import { APIResource } from '../../../resource';
+import { isRequestOptions } from '../../../core';
+import * as Core from '../../../core';
+
+export class Usage extends APIResource {
+  /**
+   * Returns cost and usage data for all accounts within an organization, aligned
+   * with the [FinOps FOCUS v1.3](https://focus.finops.org/focus-specification/v1-3/)
+   * Cost and Usage dataset specification.
+   *
+   * Each record represents one billable metric for one account on one day. This
+   * includes all metered usage, including usage that falls within free-tier
+   * allowances and may result in zero cost. The response includes usage for every
+   * account belonging to the specified organization.
+   *
+   * **Note:** Cost and pricing fields are not yet populated and will be absent from
+   * responses until billing integration is complete.
+   *
+   * When `from` and `to` are omitted, defaults to the start of the current month
+   * through today. The maximum date range is 31 days.
+   */
+  get(
+    organizationId: string,
+    query?: UsageGetParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<UsageGetResponse>;
+  get(organizationId: string, options?: Core.RequestOptions): Core.APIPromise<UsageGetResponse>;
+  get(
+    organizationId: string,
+    query: UsageGetParams | Core.RequestOptions = {},
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<UsageGetResponse> {
+    if (isRequestOptions(query)) {
+      return this.get(organizationId, {}, query);
+    }
+    return (
+      this._client.get(`/organizations/${organizationId}/billable/usage`, {
+        query,
+        ...options,
+      }) as Core.APIPromise<{ result: UsageGetResponse }>
+    )._thenUnwrap((obj) => obj.result);
+  }
+}
+
+/**
+ * Contains the array of cost and usage records.
+ */
+export type UsageGetResponse = Array<UsageGetResponse.UsageGetResponseItem>;
+
+export namespace UsageGetResponse {
+  /**
+   * A single cost and usage record for a metered product within a specific charge
+   * period, aligned with the FinOps FOCUS v1.3 specification.
+   */
+  export interface UsageGetResponseItem {
+    /**
+     * Public identifier of the Cloudflare account (account tag).
+     */
+    BillingAccountId: string;
+
+    /**
+     * Display name of the Cloudflare account.
+     */
+    BillingAccountName: string;
+
+    /**
+     * Highest-level classification of a charge based on the nature of how it gets
+     * billed. Currently only "Usage" is supported.
+     */
+    ChargeCategory: 'Usage';
+
+    /**
+     * Self-contained summary of the charge's purpose and price.
+     */
+    ChargeDescription: string;
+
+    /**
+     * Indicates how often a charge occurs. Currently only "Usage-Based" is supported.
+     */
+    ChargeFrequency: 'Usage-Based';
+
+    /**
+     * Exclusive end of the time interval during which the usage was consumed.
+     */
+    ChargePeriodEnd: string;
+
+    /**
+     * Inclusive start of the time interval during which the usage was consumed.
+     */
+    ChargePeriodStart: string;
+
+    /**
+     * Measured usage amount within the charge period. Reflects raw metered consumption
+     * before pricing transformations.
+     */
+    ConsumedQuantity: number;
+
+    /**
+     * Unit of measure for the consumed quantity (e.g., "GB", "Requests",
+     * "vCPU-Hours").
+     */
+    ConsumedUnit: string;
+
+    /**
+     * Name of the entity providing the underlying infrastructure or platform.
+     */
+    HostProviderName: string;
+
+    /**
+     * Name of the entity responsible for invoicing for the services consumed.
+     */
+    InvoiceIssuerName: string;
+
+    /**
+     * Name of the entity that made the services available for purchase.
+     */
+    ServiceProviderName: string;
+
+    /**
+     * The display name of the billable metric. Cloudflare extension; replaces FOCUS
+     * SkuMeter.
+     */
+    x_BillableMetricName: string;
+
+    /**
+     * A charge serving as the basis for invoicing, inclusive of all reduced rates and
+     * discounts while excluding the amortization of upfront charges (one-time or
+     * recurring).
+     */
+    BilledCost?: number | null;
+
+    /**
+     * Currency that a charge was billed in (ISO 4217).
+     */
+    BillingCurrency?: string | null;
+
+    /**
+     * Exclusive end of the billing cycle that contains this usage record.
+     */
+    BillingPeriodEnd?: string | null;
+
+    /**
+     * Inclusive start of the billing cycle that contains this usage record.
+     */
+    BillingPeriodStart?: string | null;
+
+    /**
+     * Indicates whether the row represents a correction to one or more charges
+     * invoiced in a previous billing period.
+     */
+    ChargeClass?: 'Correction' | null;
+
+    /**
+     * Cost calculated by multiplying ContractedUnitPrice and the corresponding
+     * PricingQuantity.
+     */
+    ContractedCost?: number | null;
+
+    /**
+     * The agreed-upon unit price for a single PricingUnit of the associated billable
+     * metric, inclusive of negotiated discounts, if present, while excluding any other
+     * discounts.
+     */
+    ContractedUnitPrice?: number | null;
+
+    /**
+     * The amortized cost of the charge after applying all reduced rates, discounts,
+     * and the applicable portion of relevant, prepaid purchases (one-time or
+     * recurring) that covered the charge.
+     */
+    EffectiveCost?: number | null;
+
+    /**
+     * Cost calculated by multiplying ListUnitPrice and the corresponding
+     * PricingQuantity.
+     */
+    ListCost?: number | null;
+
+    /**
+     * Suggested provider-published unit price for a single PricingUnit of the
+     * associated billable metric, exclusive of any discounts.
+     */
+    ListUnitPrice?: number | null;
+
+    /**
+     * Volume of a given service used or purchased, based on the PricingUnit.
+     */
+    PricingQuantity?: number | null;
+
+    /**
+     * Provider-specified measurement unit for determining unit prices, indicating how
+     * the provider rates measured usage after applying pricing rules like block
+     * pricing.
+     */
+    PricingUnit?: string | null;
+
+    /**
+     * Provider-assigned identifier for an isolated geographic area where a service is
+     * provided.
+     */
+    RegionId?: string | null;
+
+    /**
+     * Name of an isolated geographic area where a service is provided.
+     */
+    RegionName?: string | null;
+
+    /**
+     * Unique identifier assigned to a grouping of services. For Cloudflare, this is
+     * the subscription or contract ID.
+     */
+    SubAccountId?: string;
+
+    /**
+     * Name assigned to a grouping of services. For Cloudflare, this is the
+     * subscription or contract display name.
+     */
+    SubAccountName?: string;
+
+    /**
+     * The unique identifier for the billable metric in the Cloudflare catalog.
+     * Cloudflare extension; replaces FOCUS SkuId.
+     */
+    x_BillableMetricId?: string;
+
+    /**
+     * The product family the charge belongs to (e.g., "R2", "Workers"). Cloudflare
+     * extension; replaces FOCUS ServiceName.
+     */
+    x_ProductFamilyName?: string;
+
+    /**
+     * The identifier for the Cloudflare zone (zone tag). Cloudflare extension.
+     */
+    x_ZoneId?: string | null;
+
+    /**
+     * The display name of the Cloudflare zone. Cloudflare extension.
+     */
+    x_ZoneName?: string | null;
+  }
+}
+
+export interface UsageGetParams {
+  /**
+   * Start date for the usage query (ISO 8601). Required if `to` is set. When omitted
+   * along with `to`, defaults to the start of the current month. Filters by charge
+   * period (when consumption happened), not billing period. The maximum date range
+   * is 31 days.
+   */
+  from?: string;
+
+  /**
+   * Filter results by billable metric id (e.g., workers_standard_requests).
+   */
+  metric?: string;
+
+  /**
+   * End date for the usage query (ISO 8601). Required if `from` is set. When omitted
+   * along with `from`, defaults to today. Filters by charge period (when consumption
+   * happened), not billing period. The maximum date range is 31 days.
+   */
+  to?: string;
+}
+
+export declare namespace Usage {
+  export { type UsageGetResponse as UsageGetResponse, type UsageGetParams as UsageGetParams };
+}

--- a/src/resources/organizations/index.ts
+++ b/src/resources/organizations/index.ts
@@ -1,5 +1,6 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
+export { Billing } from './billing/index';
 export { Logs } from './logs/index';
 export {
   OrganizationProfileResource,

--- a/src/resources/organizations/organizations.ts
+++ b/src/resources/organizations/organizations.ts
@@ -9,6 +9,8 @@ import {
   OrganizationProfileResource,
   OrganizationProfileUpdateParams,
 } from './organization-profile';
+import * as BillingAPI from './billing/billing';
+import { Billing } from './billing/billing';
 import * as LogsAPI from './logs/logs';
 import { Logs } from './logs/logs';
 import { SinglePage } from '../../pagination';
@@ -17,6 +19,7 @@ export class Organizations extends APIResource {
   organizationProfile: OrganizationProfileAPI.OrganizationProfileResource =
     new OrganizationProfileAPI.OrganizationProfileResource(this._client);
   logs: LogsAPI.Logs = new LogsAPI.Logs(this._client);
+  billing: BillingAPI.Billing = new BillingAPI.Billing(this._client);
 
   /**
    * Create a new organization for a user. (Currently in Public Beta - see
@@ -300,6 +303,7 @@ export namespace OrganizationListParams {
 Organizations.OrganizationsSinglePage = OrganizationsSinglePage;
 Organizations.OrganizationProfileResource = OrganizationProfileResource;
 Organizations.Logs = Logs;
+Organizations.Billing = Billing;
 
 export declare namespace Organizations {
   export {
@@ -318,4 +322,6 @@ export declare namespace Organizations {
   };
 
   export { Logs as Logs };
+
+  export { Billing as Billing };
 }

--- a/src/resources/radar/http/http.ts
+++ b/src/resources/radar/http/http.ts
@@ -831,6 +831,28 @@ export interface HTTPTimeseriesParams {
   browserFamily?: Array<'CHROME' | 'EDGE' | 'FIREFOX' | 'SAFARI'>;
 
   /**
+   * Filters results by content type category.
+   */
+  contentType?: Array<
+    | 'HTML'
+    | 'IMAGES'
+    | 'JSON'
+    | 'JAVASCRIPT'
+    | 'CSS'
+    | 'PLAIN_TEXT'
+    | 'FONTS'
+    | 'XML'
+    | 'YAML'
+    | 'VIDEO'
+    | 'AUDIO'
+    | 'MARKDOWN'
+    | 'DOCUMENTS'
+    | 'BINARY'
+    | 'SERIALIZATION'
+    | 'OTHER'
+  >;
+
+  /**
    * Filters results by continent. Specify a comma-separated list of alpha-2 codes.
    * Prefix with `-` to exclude continents from results. For example, `-EU,NA`
    * excludes results from EU, but includes results from NA.

--- a/src/resources/zero-trust/access/applications/policies.ts
+++ b/src/resources/zero-trust/access/applications/policies.ts
@@ -332,7 +332,8 @@ export type AccessRule =
   | AccessRule.AccessOIDCClaimRule
   | ServiceTokenRule
   | AccessRule.AccessLinkedAppTokenRule
-  | AccessRule.AccessUserRiskScoreRule;
+  | AccessRule.AccessUserRiskScoreRule
+  | AccessRule.AccessCloudflareAccountMemberRule;
 
 export namespace AccessRule {
   /**
@@ -452,6 +453,23 @@ export namespace AccessRule {
       user_risk_score: Array<'low' | 'medium' | 'high' | 'unscored'>;
     }
   }
+
+  /**
+   * Matches users who are members of a specific Cloudflare account. Requires a
+   * Cloudflare identity provider.
+   */
+  export interface AccessCloudflareAccountMemberRule {
+    cloudflare_account_member: AccessCloudflareAccountMemberRule.CloudflareAccountMember;
+  }
+
+  export namespace AccessCloudflareAccountMemberRule {
+    export interface CloudflareAccountMember {
+      /**
+       * Identifier.
+       */
+      account_id?: string;
+    }
+  }
 }
 
 /**
@@ -482,7 +500,8 @@ export type AccessRuleParam =
   | AccessRuleParam.AccessOIDCClaimRule
   | ServiceTokenRuleParam
   | AccessRuleParam.AccessLinkedAppTokenRule
-  | AccessRuleParam.AccessUserRiskScoreRule;
+  | AccessRuleParam.AccessUserRiskScoreRule
+  | AccessRuleParam.AccessCloudflareAccountMemberRule;
 
 export namespace AccessRuleParam {
   /**
@@ -600,6 +619,23 @@ export namespace AccessRuleParam {
        * unscored.
        */
       user_risk_score: Array<'low' | 'medium' | 'high' | 'unscored'>;
+    }
+  }
+
+  /**
+   * Matches users who are members of a specific Cloudflare account. Requires a
+   * Cloudflare identity provider.
+   */
+  export interface AccessCloudflareAccountMemberRule {
+    cloudflare_account_member: AccessCloudflareAccountMemberRule.CloudflareAccountMember;
+  }
+
+  export namespace AccessCloudflareAccountMemberRule {
+    export interface CloudflareAccountMember {
+      /**
+       * Identifier.
+       */
+      account_id?: string;
     }
   }
 }

--- a/src/resources/zero-trust/identity-providers/identity-providers.ts
+++ b/src/resources/zero-trust/identity-providers/identity-providers.ts
@@ -562,7 +562,8 @@ export type IdentityProvider =
   | IdentityProvider.AccessPingone
   | IdentityProvider.AccessSAML
   | IdentityProvider.AccessYandex
-  | IdentityProvider.AccessOnetimepin;
+  | IdentityProvider.AccessOnetimepin
+  | IdentityProvider.AccessCloudflare;
 
 export namespace IdentityProvider {
   export interface AccessCentrify {
@@ -2340,6 +2341,133 @@ export namespace IdentityProvider {
       }
     }
   }
+
+  export interface AccessCloudflare {
+    /**
+     * The configuration parameters for the identity provider. To view the required
+     * parameters for a specific provider, refer to our
+     * [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/).
+     */
+    config: AccessCloudflare.Config;
+
+    /**
+     * The name of the identity provider, shown to users on the login page.
+     */
+    name: string;
+
+    /**
+     * The type of identity provider. To determine the value for a specific provider,
+     * refer to our
+     * [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/).
+     */
+    type: IdentityProvidersAPI.IdentityProviderType;
+
+    /**
+     * UUID.
+     */
+    id?: string;
+
+    /**
+     * The SAML encryption certificate set details, including current and previous
+     * certificates. Only present for SAML identity providers with a certificate set
+     * assigned.
+     */
+    saml_certificate_set?: AccessCloudflare.SAMLCertificateSet;
+
+    /**
+     * The UID of the SAML encryption certificate set assigned to this Identity
+     * Provider. Only present for SAML identity providers with encryption configured.
+     * Create a certificate set via POST to
+     * `/identity_providers/{id}/saml_certificate`.
+     */
+    saml_certificate_set_id?: string;
+
+    /**
+     * The configuration settings for enabling a System for Cross-Domain Identity
+     * Management (SCIM) with the identity provider.
+     */
+    scim_config?: IdentityProvidersAPI.IdentityProviderSCIMConfig;
+  }
+
+  export namespace AccessCloudflare {
+    /**
+     * The configuration parameters for the identity provider. To view the required
+     * parameters for a specific provider, refer to our
+     * [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/).
+     */
+    export interface Config {
+      redirect_url?: string;
+
+      /**
+       * When enabled, only users who are members of your Cloudflare account can
+       * authenticate through this identity provider. When disabled, any user with a
+       * Cloudflare account can authenticate, subject to your Access policies.
+       */
+      restrict_to_account_members?: boolean;
+    }
+
+    /**
+     * The SAML encryption certificate set details, including current and previous
+     * certificates. Only present for SAML identity providers with a certificate set
+     * assigned.
+     */
+    export interface SAMLCertificateSet {
+      /**
+       * Timestamp when the certificate set was created
+       */
+      created_at: string;
+
+      /**
+       * Unique identifier for the certificate set
+       */
+      uid: string;
+
+      /**
+       * Timestamp when the certificate set was last updated (e.g., during rotation)
+       */
+      updated_at: string;
+
+      /**
+       * The currently active certificate used for encrypting SAML assertions
+       */
+      current_certificate?: SAMLCertificateSet.CurrentCertificate;
+
+      /**
+       * The previous certificate, maintained during rotation to ensure continuity. Null
+       * if no rotation has occurred. Mirrors the structure of `saml_certificate`.
+       */
+      previous_certificate?: unknown | null;
+    }
+
+    export namespace SAMLCertificateSet {
+      /**
+       * The currently active certificate used for encrypting SAML assertions
+       */
+      export interface CurrentCertificate {
+        /**
+         * Indicates whether this is the currently active certificate
+         */
+        is_current: boolean;
+
+        /**
+         * Certificate expiration date. Certificates are automatically rotated 30 days
+         * before expiration.
+         */
+        not_after: string;
+
+        /**
+         * PEM-encoded X.509 certificate containing the public key. Configure this
+         * certificate in your external SAML Identity Provider to enable encryption.
+         */
+        public_certificate: string;
+
+        /**
+         * Unique identifier for the certificate
+         */
+        uid: string;
+      }
+    }
+  }
 }
 
 export type IdentityProviderParam =
@@ -2356,7 +2484,8 @@ export type IdentityProviderParam =
   | IdentityProviderParam.AccessPingone
   | IdentityProviderParam.AccessSAML
   | IdentityProviderParam.AccessYandex
-  | IdentityProviderParam.AccessOnetimepin;
+  | IdentityProviderParam.AccessOnetimepin
+  | IdentityProviderParam.AccessCloudflare;
 
 export namespace IdentityProviderParam {
   export interface AccessCentrify {
@@ -3162,6 +3291,57 @@ export namespace IdentityProviderParam {
      */
     export interface Config {}
   }
+
+  export interface AccessCloudflare {
+    /**
+     * The configuration parameters for the identity provider. To view the required
+     * parameters for a specific provider, refer to our
+     * [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/).
+     */
+    config: AccessCloudflare.Config;
+
+    /**
+     * The name of the identity provider, shown to users on the login page.
+     */
+    name: string;
+
+    /**
+     * The type of identity provider. To determine the value for a specific provider,
+     * refer to our
+     * [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/).
+     */
+    type: IdentityProvidersAPI.IdentityProviderTypeParam;
+
+    /**
+     * The UID of the SAML encryption certificate set assigned to this Identity
+     * Provider. Only present for SAML identity providers with encryption configured.
+     * Create a certificate set via POST to
+     * `/identity_providers/{id}/saml_certificate`.
+     */
+    saml_certificate_set_id?: string;
+
+    /**
+     * The configuration settings for enabling a System for Cross-Domain Identity
+     * Management (SCIM) with the identity provider.
+     */
+    scim_config?: IdentityProvidersAPI.IdentityProviderSCIMConfigParam;
+  }
+
+  export namespace AccessCloudflare {
+    /**
+     * The configuration parameters for the identity provider. To view the required
+     * parameters for a specific provider, refer to our
+     * [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/).
+     */
+    export interface Config {
+      /**
+       * When enabled, only users who are members of your Cloudflare account can
+       * authenticate through this identity provider. When disabled, any user with a
+       * Cloudflare account can authenticate, subject to your Access policies.
+       */
+      restrict_to_account_members?: boolean;
+    }
+  }
 }
 
 /**
@@ -3265,7 +3445,8 @@ export type IdentityProviderType =
   | 'okta'
   | 'onelogin'
   | 'pingone'
-  | 'yandex';
+  | 'yandex'
+  | 'cloudflare';
 
 /**
  * The type of identity provider. To determine the value for a specific provider,
@@ -3286,7 +3467,8 @@ export type IdentityProviderTypeParam =
   | 'okta'
   | 'onelogin'
   | 'pingone'
-  | 'yandex';
+  | 'yandex'
+  | 'cloudflare';
 
 export type IdentityProviderListResponse =
   | AzureAD
@@ -3301,7 +3483,9 @@ export type IdentityProviderListResponse =
   | IdentityProviderListResponse.AccessOnelogin
   | IdentityProviderListResponse.AccessPingone
   | IdentityProviderListResponse.AccessSAML
-  | IdentityProviderListResponse.AccessYandex;
+  | IdentityProviderListResponse.AccessYandex
+  | IdentityProviderListResponse.AccessOnetimepin
+  | IdentityProviderListResponse.AccessCloudflare;
 
 export namespace IdentityProviderListResponse {
   export interface AccessCentrify {
@@ -4959,6 +5143,253 @@ export namespace IdentityProviderListResponse {
       }
     }
   }
+
+  export interface AccessOnetimepin {
+    /**
+     * The configuration parameters for the identity provider. To view the required
+     * parameters for a specific provider, refer to our
+     * [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/).
+     */
+    config: AccessOnetimepin.Config;
+
+    /**
+     * The name of the identity provider, shown to users on the login page.
+     */
+    name: string;
+
+    /**
+     * The type of identity provider. To determine the value for a specific provider,
+     * refer to our
+     * [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/).
+     */
+    type: IdentityProvidersAPI.IdentityProviderType;
+
+    /**
+     * UUID.
+     */
+    id?: string;
+
+    /**
+     * The SAML encryption certificate set details, including current and previous
+     * certificates. Only present for SAML identity providers with a certificate set
+     * assigned.
+     */
+    saml_certificate_set?: AccessOnetimepin.SAMLCertificateSet;
+
+    /**
+     * The UID of the SAML encryption certificate set assigned to this Identity
+     * Provider. Only present for SAML identity providers with encryption configured.
+     * Create a certificate set via POST to
+     * `/identity_providers/{id}/saml_certificate`.
+     */
+    saml_certificate_set_id?: string;
+
+    /**
+     * The configuration settings for enabling a System for Cross-Domain Identity
+     * Management (SCIM) with the identity provider.
+     */
+    scim_config?: IdentityProvidersAPI.IdentityProviderSCIMConfig;
+  }
+
+  export namespace AccessOnetimepin {
+    /**
+     * The configuration parameters for the identity provider. To view the required
+     * parameters for a specific provider, refer to our
+     * [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/).
+     */
+    export interface Config {
+      redirect_url?: string;
+    }
+
+    /**
+     * The SAML encryption certificate set details, including current and previous
+     * certificates. Only present for SAML identity providers with a certificate set
+     * assigned.
+     */
+    export interface SAMLCertificateSet {
+      /**
+       * Timestamp when the certificate set was created
+       */
+      created_at: string;
+
+      /**
+       * Unique identifier for the certificate set
+       */
+      uid: string;
+
+      /**
+       * Timestamp when the certificate set was last updated (e.g., during rotation)
+       */
+      updated_at: string;
+
+      /**
+       * The currently active certificate used for encrypting SAML assertions
+       */
+      current_certificate?: SAMLCertificateSet.CurrentCertificate;
+
+      /**
+       * The previous certificate, maintained during rotation to ensure continuity. Null
+       * if no rotation has occurred. Mirrors the structure of `saml_certificate`.
+       */
+      previous_certificate?: unknown | null;
+    }
+
+    export namespace SAMLCertificateSet {
+      /**
+       * The currently active certificate used for encrypting SAML assertions
+       */
+      export interface CurrentCertificate {
+        /**
+         * Indicates whether this is the currently active certificate
+         */
+        is_current: boolean;
+
+        /**
+         * Certificate expiration date. Certificates are automatically rotated 30 days
+         * before expiration.
+         */
+        not_after: string;
+
+        /**
+         * PEM-encoded X.509 certificate containing the public key. Configure this
+         * certificate in your external SAML Identity Provider to enable encryption.
+         */
+        public_certificate: string;
+
+        /**
+         * Unique identifier for the certificate
+         */
+        uid: string;
+      }
+    }
+  }
+
+  export interface AccessCloudflare {
+    /**
+     * The configuration parameters for the identity provider. To view the required
+     * parameters for a specific provider, refer to our
+     * [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/).
+     */
+    config: AccessCloudflare.Config;
+
+    /**
+     * The name of the identity provider, shown to users on the login page.
+     */
+    name: string;
+
+    /**
+     * The type of identity provider. To determine the value for a specific provider,
+     * refer to our
+     * [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/).
+     */
+    type: IdentityProvidersAPI.IdentityProviderType;
+
+    /**
+     * UUID.
+     */
+    id?: string;
+
+    /**
+     * The SAML encryption certificate set details, including current and previous
+     * certificates. Only present for SAML identity providers with a certificate set
+     * assigned.
+     */
+    saml_certificate_set?: AccessCloudflare.SAMLCertificateSet;
+
+    /**
+     * The UID of the SAML encryption certificate set assigned to this Identity
+     * Provider. Only present for SAML identity providers with encryption configured.
+     * Create a certificate set via POST to
+     * `/identity_providers/{id}/saml_certificate`.
+     */
+    saml_certificate_set_id?: string;
+
+    /**
+     * The configuration settings for enabling a System for Cross-Domain Identity
+     * Management (SCIM) with the identity provider.
+     */
+    scim_config?: IdentityProvidersAPI.IdentityProviderSCIMConfig;
+  }
+
+  export namespace AccessCloudflare {
+    /**
+     * The configuration parameters for the identity provider. To view the required
+     * parameters for a specific provider, refer to our
+     * [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/).
+     */
+    export interface Config {
+      redirect_url?: string;
+
+      /**
+       * When enabled, only users who are members of your Cloudflare account can
+       * authenticate through this identity provider. When disabled, any user with a
+       * Cloudflare account can authenticate, subject to your Access policies.
+       */
+      restrict_to_account_members?: boolean;
+    }
+
+    /**
+     * The SAML encryption certificate set details, including current and previous
+     * certificates. Only present for SAML identity providers with a certificate set
+     * assigned.
+     */
+    export interface SAMLCertificateSet {
+      /**
+       * Timestamp when the certificate set was created
+       */
+      created_at: string;
+
+      /**
+       * Unique identifier for the certificate set
+       */
+      uid: string;
+
+      /**
+       * Timestamp when the certificate set was last updated (e.g., during rotation)
+       */
+      updated_at: string;
+
+      /**
+       * The currently active certificate used for encrypting SAML assertions
+       */
+      current_certificate?: SAMLCertificateSet.CurrentCertificate;
+
+      /**
+       * The previous certificate, maintained during rotation to ensure continuity. Null
+       * if no rotation has occurred. Mirrors the structure of `saml_certificate`.
+       */
+      previous_certificate?: unknown | null;
+    }
+
+    export namespace SAMLCertificateSet {
+      /**
+       * The currently active certificate used for encrypting SAML assertions
+       */
+      export interface CurrentCertificate {
+        /**
+         * Indicates whether this is the currently active certificate
+         */
+        is_current: boolean;
+
+        /**
+         * Certificate expiration date. Certificates are automatically rotated 30 days
+         * before expiration.
+         */
+        not_after: string;
+
+        /**
+         * PEM-encoded X.509 certificate containing the public key. Configure this
+         * certificate in your external SAML Identity Provider to enable encryption.
+         */
+        public_certificate: string;
+
+        /**
+         * Unique identifier for the certificate
+         */
+        uid: string;
+      }
+    }
+  }
 }
 
 export interface IdentityProviderDeleteResponse {
@@ -4982,7 +5413,8 @@ export type IdentityProviderCreateParams =
   | IdentityProviderCreateParams.AccessPingone
   | IdentityProviderCreateParams.AccessSAML
   | IdentityProviderCreateParams.AccessYandex
-  | IdentityProviderCreateParams.AccessOnetimepin;
+  | IdentityProviderCreateParams.AccessOnetimepin
+  | IdentityProviderCreateParams.AccessCloudflare;
 
 export declare namespace IdentityProviderCreateParams {
   export interface AzureAD {
@@ -6047,6 +6479,69 @@ export declare namespace IdentityProviderCreateParams {
      */
     export interface Config {}
   }
+
+  export interface AccessCloudflare {
+    /**
+     * Body param: The configuration parameters for the identity provider. To view the
+     * required parameters for a specific provider, refer to our
+     * [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/).
+     */
+    config: AccessCloudflare.Config;
+
+    /**
+     * Body param: The name of the identity provider, shown to users on the login page.
+     */
+    name: string;
+
+    /**
+     * Body param: The type of identity provider. To determine the value for a specific
+     * provider, refer to our
+     * [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/).
+     */
+    type: IdentityProviderTypeParam;
+
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The UID of the SAML encryption certificate set assigned to this
+     * Identity Provider. Only present for SAML identity providers with encryption
+     * configured. Create a certificate set via POST to
+     * `/identity_providers/{id}/saml_certificate`.
+     */
+    saml_certificate_set_id?: string;
+
+    /**
+     * Body param: The configuration settings for enabling a System for Cross-Domain
+     * Identity Management (SCIM) with the identity provider.
+     */
+    scim_config?: IdentityProviderSCIMConfigParam;
+  }
+
+  export namespace AccessCloudflare {
+    /**
+     * The configuration parameters for the identity provider. To view the required
+     * parameters for a specific provider, refer to our
+     * [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/).
+     */
+    export interface Config {
+      /**
+       * When enabled, only users who are members of your Cloudflare account can
+       * authenticate through this identity provider. When disabled, any user with a
+       * Cloudflare account can authenticate, subject to your Access policies.
+       */
+      restrict_to_account_members?: boolean;
+    }
+  }
 }
 
 export type IdentityProviderUpdateParams =
@@ -6063,7 +6558,8 @@ export type IdentityProviderUpdateParams =
   | IdentityProviderUpdateParams.AccessPingone
   | IdentityProviderUpdateParams.AccessSAML
   | IdentityProviderUpdateParams.AccessYandex
-  | IdentityProviderUpdateParams.AccessOnetimepin;
+  | IdentityProviderUpdateParams.AccessOnetimepin
+  | IdentityProviderUpdateParams.AccessCloudflare;
 
 export declare namespace IdentityProviderUpdateParams {
   export interface AzureAD {
@@ -7127,6 +7623,69 @@ export declare namespace IdentityProviderUpdateParams {
      * [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/).
      */
     export interface Config {}
+  }
+
+  export interface AccessCloudflare {
+    /**
+     * Body param: The configuration parameters for the identity provider. To view the
+     * required parameters for a specific provider, refer to our
+     * [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/).
+     */
+    config: AccessCloudflare.Config;
+
+    /**
+     * Body param: The name of the identity provider, shown to users on the login page.
+     */
+    name: string;
+
+    /**
+     * Body param: The type of identity provider. To determine the value for a specific
+     * provider, refer to our
+     * [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/).
+     */
+    type: IdentityProviderTypeParam;
+
+    /**
+     * Path param: The Account ID to use for this endpoint. Mutually exclusive with the
+     * Zone ID.
+     */
+    account_id?: string;
+
+    /**
+     * Path param: The Zone ID to use for this endpoint. Mutually exclusive with the
+     * Account ID.
+     */
+    zone_id?: string;
+
+    /**
+     * Body param: The UID of the SAML encryption certificate set assigned to this
+     * Identity Provider. Only present for SAML identity providers with encryption
+     * configured. Create a certificate set via POST to
+     * `/identity_providers/{id}/saml_certificate`.
+     */
+    saml_certificate_set_id?: string;
+
+    /**
+     * Body param: The configuration settings for enabling a System for Cross-Domain
+     * Identity Management (SCIM) with the identity provider.
+     */
+    scim_config?: IdentityProviderSCIMConfigParam;
+  }
+
+  export namespace AccessCloudflare {
+    /**
+     * The configuration parameters for the identity provider. To view the required
+     * parameters for a specific provider, refer to our
+     * [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/).
+     */
+    export interface Config {
+      /**
+       * When enabled, only users who are members of your Cloudflare account can
+       * authenticate through this identity provider. When disabled, any user with a
+       * Cloudflare account can authenticate, subject to your Access policies.
+       */
+      restrict_to_account_members?: boolean;
+    }
   }
 }
 

--- a/tests/api-resources/organizations/billing/usage.test.ts
+++ b/tests/api-resources/organizations/billing/usage.test.ts
@@ -1,0 +1,47 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+import Cloudflare from 'cloudflare';
+import { Response } from 'node-fetch';
+
+const client = new Cloudflare({
+  apiKey: '144c9defac04969c7bfad8efaa8ea194',
+  apiEmail: 'user@example.com',
+  baseURL: process.env['TEST_API_BASE_URL'] ?? 'http://127.0.0.1:4010',
+});
+
+describe('resource usage', () => {
+  test('get', async () => {
+    const responsePromise = client.organizations.billing.usage.get('023e105f4ecef8ad9ca31a8372d0c353');
+    const rawResponse = await responsePromise.asResponse();
+    expect(rawResponse).toBeInstanceOf(Response);
+    const response = await responsePromise;
+    expect(response).not.toBeInstanceOf(Response);
+    const dataAndResponse = await responsePromise.withResponse();
+    expect(dataAndResponse.data).toBe(response);
+    expect(dataAndResponse.response).toBe(rawResponse);
+  });
+
+  test('get: request options instead of params are passed correctly', async () => {
+    // ensure the request options are being passed correctly by passing an invalid HTTP method in order to cause an error
+    await expect(
+      client.organizations.billing.usage.get('023e105f4ecef8ad9ca31a8372d0c353', {
+        path: '/_stainless_unknown_path',
+      }),
+    ).rejects.toThrow(Cloudflare.NotFoundError);
+  });
+
+  test('get: request options and params are passed correctly', async () => {
+    // ensure the request options are being passed correctly by passing an invalid HTTP method in order to cause an error
+    await expect(
+      client.organizations.billing.usage.get(
+        '023e105f4ecef8ad9ca31a8372d0c353',
+        {
+          from: '2025-05-01',
+          metric: 'workers_standard_requests',
+          to: '2025-05-31',
+        },
+        { path: '/_stainless_unknown_path' },
+      ),
+    ).rejects.toThrow(Cloudflare.NotFoundError);
+  });
+});

--- a/tests/api-resources/organizations/logs/audit.test.ts
+++ b/tests/api-resources/organizations/logs/audit.test.ts
@@ -10,7 +10,7 @@ const client = new Cloudflare({
 });
 
 describe('resource audit', () => {
-  // TODO: required params 'since' and 'before' not populated by Prism mock
+  // TODO DS-16345: required params 'since' and 'before' not populated by Prism mock
   test.skip('list: only required params', async () => {
     const responsePromise = client.organizations.logs.audit.list('a67e14daa5f8dceeb91fe5449ba496ef', {
       before: '2024-10-31',
@@ -25,7 +25,7 @@ describe('resource audit', () => {
     expect(dataAndResponse.response).toBe(rawResponse);
   });
 
-  // TODO: required params 'since' and 'before' not populated by Prism mock
+  // TODO DS-16345: required params 'since' and 'before' not populated by Prism mock
   test.skip('list: required and optional params', async () => {
     const response = await client.organizations.logs.audit.list('a67e14daa5f8dceeb91fe5449ba496ef', {
       before: '2024-10-31',

--- a/tests/api-resources/radar/http/http.test.ts
+++ b/tests/api-resources/radar/http/http.test.ts
@@ -87,6 +87,7 @@ describe('resource http', () => {
           asn: ['string'],
           botClass: ['LIKELY_AUTOMATED'],
           browserFamily: ['CHROME'],
+          contentType: ['HTML'],
           continent: ['string'],
           dateEnd: ['2019-12-27T18:11:19.117Z'],
           dateRange: ['7d'],


### PR DESCRIPTION
## Codegen Sync: staging-next -> next

Synced 3 of 8 changed resources from `staging-next` as of 2026-05-20.

Source: `origin/staging-next` @ b5b4cc693
Base:   `origin/next` @ 45bd3e2c6

### Local Validation (all three gates pass)

| Gate | Command | Result |
|------|---------|--------|
| Type check | `npx tsc --noEmit` | pass |
| Lint | `ESLINT_USE_FLAT_CONFIG=false npx eslint --ext ts,js .` | pass |
| Breaking changes | `./scripts/detect-breaking-changes origin/next` | pass (exit 0) |

### Integrated Resources

| Resource | Type | Summary |
|----------|------|---------|
| organizations | feat | add billing sub-resource (Billing -> Usage -> get method) |
| radar | chore | update codegen output |
| zero-trust | chore | update codegen output |

### Deferred: Breaking Changes (still unresolved)

These resources have spec-driven changes that affect SDK contract.
`api-gateway` and `cache` carry over from the previous sync; `billing` and
`email-security` are new this cycle.

| Resource | Change | Notes |
|----------|--------|-------|
| api-gateway | `discovery.operations.edit()` removed | Same as previous sync |
| cache | `originCloudRegions.create` -> `update` (POST -> PUT) | Same as previous sync |
| cache | `originCloudRegions.bulkEdit` -> `bulkUpdate` | Same as previous sync |
| cache | `originCloudRegions.edit` removed | Same as previous sync |
| billing | `usage.paygo` endpoint URL changed: `/billing/usage/paygo` -> `/paygo-usage` | SDK signature unchanged, but underlying API contract changed; defer until spec-owner confirms |
| email-security | `InvestigateListParams.action_log` parameter removed | Removes a query parameter from public type surface |

Note on `billing`: this resource also adds a non-breaking `usage.get` method
(new endpoint `GET /accounts/{account_id}/billable/usage`). It is held back
along with the rest of the resource because the resource boundary is the
top-level directory. Can split into a non-breaking-only PR if you want
`usage.get` in sooner.

The local `detect-breaking-changes` script flagged `email-security` directly
(removed query param breaks old test). For `billing`, the script passes
because the SDK method signature is unchanged; the endpoint URL change was
caught by the surface analyzer (`scripts/common/summarize-diff.ts`).

### Deferred: Codegen Regression (still unresolved)

`billing` is now fixed by the codegen team (`Usage.paygo` re-added plus a
new `Usage.get` method), so this list is shorter than before.

| Resource | Root Cause |
|----------|------------|
| addressing | `RegionalHostnames` and `Regions` classes generated empty -- methods exist on `next`, stripped on `staging-next`, new tests still reference them |

### Shared Changes (codegen artifacts only)

- `.stats.yml` -- spec hash bump
- `scripts/detect-breaking-changes` -- updated test path list

Intentionally NOT touched:
- `.github/workflows/*` -- human-owned
- `.release-please-manifest.json`, `CHANGELOG.md`, `package.json`, `src/version.ts` -- release-please-bot owned
- `src/index.ts`, `src/resources/index.ts`, root `api.md` -- no diff in this sync

Tracker: `command-center/.local/sync-typescript-2026-05-20.md` (in devstack)
