### PR TITLE
fix: set repository url to public GitHub repo for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
   "type": "commonjs",
-  "repository": "gitlab:cloudflare/sdks/cloudflare-typescript",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cloudflare/cloudflare-typescript.git"
+  },
   "license": "Apache-2.0",
   "packageManager": "yarn@1.22.22",
   "files": [


### PR DESCRIPTION
## Problem

npm provenance verification failed with:

```
Error verifying sigstore provenance bundle:
"repository.url" is "git+https://gitlab.com/cloudflare/sdks/cloudflare-typescript.git",
expected to match "https://github.com/cloudflare/cloudflare-typescript" from provenance
```

The `repository` field in `package.json` was set to the internal GitLab repo when the `typescript` target was bootstrapped. npm's provenance requires this to match the GitHub repo running the workflow.

## Fix

Change `repository` from `"gitlab:cloudflare/sdks/cloudflare-typescript"` to the correct public GitHub URL.