### PR TITLE
fix: keep slashes in model name for ai.run route

### DIFF
--- a/src/resources/ai/ai.ts
+++ b/src/resources/ai/ai.ts
@@ -42,7 +42,6 @@ import {
 import { APIPromise } from '../../core/api-promise';
 import { type Uploadable } from '../../core/uploads';
 import { RequestOptions } from '../../internal/request-options';
-import { path } from '../../internal/utils/path';
 
 export class BaseAI extends APIResource {
   static override readonly _key: readonly ['ai'] = Object.freeze(['ai'] as const);
@@ -61,7 +60,7 @@ export class BaseAI extends APIResource {
   run(modelName: string, params: AIRunParams, options?: RequestOptions): APIPromise<AIRunResponse> {
     const { account_id, ...body } = params;
     return (
-      this._client.post(path`/accounts/${account_id}/ai/run/${modelName}`, {
+      this._client.post(`/accounts/${account_id}/ai/run/${modelName}`, {
         body,
         ...options,
       }) as APIPromise<{ result: AIRunResponse }>

--- a/tests/api-resources/ai/ai.test.ts
+++ b/tests/api-resources/ai/ai.test.ts
@@ -42,3 +42,29 @@ const runTests = (client: PartialCloudflare<{ ai: BaseAI }>) => {
 };
 describe('resource ai', () => runTests(client));
 describe('resource ai (tree shakable, base)', () => runTests(partialClient));
+
+test('run: keeps `/` in model name unencoded', async () => {
+  let capturedUrl: string | undefined;
+  const fetchSpy = (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    capturedUrl = String(url);
+    return Promise.resolve(
+      new Response(JSON.stringify({}), { headers: { 'Content-Type': 'application/json' } }),
+    );
+  };
+
+  const client = new Cloudflare({
+    baseURL: 'http://localhost:5000/',
+    apiKey: '144c9defac04969c7bfad8efaa8ea194',
+    apiEmail: 'user@example.com',
+    fetch: fetchSpy,
+  });
+
+  await client.ai.run('@cf/meta/llama-3.3-70b-instruct-fp8-fast', {
+    account_id: '023e105f4ecef8ad9ca31a8372d0c353',
+    text: 'x',
+  });
+
+  expect(capturedUrl).toBe(
+    'http://localhost:5000/accounts/023e105f4ecef8ad9ca31a8372d0c353/ai/run/@cf/meta/llama-3.3-70b-instruct-fp8-fast',
+  );
+});


### PR DESCRIPTION

## Bug

`ai.run()` percent-encodes the `/` in the model slug, e.g. `@cf/meta/llama-3.3-70b-instruct-fp8-fast` becomes `@cf%2Fmeta%2Fllama-...`. The Workers AI endpoint `/accounts/{id}/ai/run/{model}` requires the model name with literal `/` separators, so every request fails with:

```json
400 {"success":false,"errors":[{"code":7000,"message":"No route for that URI"}]}
```

## Root cause

The `path` template tag used to build the route percent-encodes every path parameter (including `/`). Verified against the live API: the same request succeeds via `curl` and via `client.post()` with a plain string.

## Fix

Build the route with a plain string so the model name keeps its slashes. `account_id` is a hex slug and safe as-is.

```ts
this._client.post(`/accounts/${account_id}/ai/run/${modelName}`, { body, ...options })
```

## Tests

Added `run: keeps / in model name unencoded` — mocks `fetch`, asserts the full request URL contains the literal `/` separators. Prettier/eslint/tsc clean.