### PR TITLE
fix: set repository url to public GitHub repo for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
   "type": "commonjs",
-  "repository": "gitlab:cloudflare/cloudflare-typescript",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cloudflare/cloudflare-typescript.git"
+  },
   "license": "Apache-2.0",
   "packageManager": "yarn@1.22.22",
   "files": [


### PR DESCRIPTION
The `repository` field in `package.json` was overwritten back to the GitLab URL by the v7.1.0 release PR (#2797), causing the npm publish to fail again with:

```
npm error code E422
npm error Error verifying sigstore provenance bundle: Failed to validate repository information:
  package.json: "repository.url" is "git+https://gitlab.com/cloudflare/cloudflare-typescript.git",
  expected to match "https://github.com/cloudflare/cloudflare-typescript" from provenance
```

This re-applies the fix from #2793.